### PR TITLE
Add deploy.sh and update installation section in Readme.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,33 @@
 # Prerequisites
 *.d
+
 # Object files
 *.o
 *.ko
 *.obj
 *.elf
+
 # Linker output
 *.ilk
 *.map
 *.exp
+
 # Precompiled Headers
 *.gch
 *.pch
+
 # Libraries
 *.lib
 *.a
 *.la
 *.lo
+
 # Shared objects (inc. Windows DLLs)
 *.dll
 *.so
 *.so.*
 *.dylib
+
 # Executables
 *.exe
 *.out
@@ -29,11 +35,13 @@
 *.i*86
 *.x86_64
 *.hex
+
 # Debug files
 *.dSYM/
 *.su
 *.idb
 *.pdb
+
 # Kernel Module Compile Results
 *.mod*
 *.cmd

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ important work by saving and such beforehand.
 ## DKMS installation
 
 If you want to have the driver available at startup, it will be convenient to
-register it in DKMS. This can be done completely automatically with the script
-`deploy.sh`.
+register it in DKMS. An executable explanation of how to do so can be found in
+the script `deploy.sh`. Since registering a kernel module in DKMS is a major
+intervention, only execute it if you understand what the script does.
 
 ## Raspberry Pi Access Point
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ important work by saving and such beforehand.
 
 ## DKMS installation
 
-If you want to have the driver available at startup, it will you convenient to
+If you want to have the driver available at startup, it will be convenient to
 register it in DKMS. This can be done completely automatically with the script
 `deploy.sh`.
 

--- a/README.md
+++ b/README.md
@@ -17,17 +17,21 @@ Build confirmed on:
 ```
 Linux version 5.4.0-4-amd64 (debian-kernel@lists.debian.org) (gcc version 9.2.1 20200203 (Debian 9.2.1-28)) #1 SMP Debian 5.4.19-1 (2020-02-13)
 ```
+
+## Simple Usage
+
+In order to make direct use of the driver it should suffice to build the driver
+with `make` and to load it with `insmod 88x2bu.ko`. This will allow you
+to use the driver directly without changing your system persistently.
+
+It might happen that your system freezes instantaneously. Ensure to not loose
+important work by saving and such beforehand.
+
 ## DKMS installation
 
-```bash
-cd rtl88x2bu
-VER=$(sed -n 's/\PACKAGE_VERSION="\(.*\)"/\1/p' dkms.conf)
-sudo rsync -rvhP ./ /usr/src/rtl88x2bu-${VER}
-sudo dkms add -m rtl88x2bu -v ${VER}
-sudo dkms build -m rtl88x2bu -v ${VER}
-sudo dkms install -m rtl88x2bu -v ${VER}
-sudo modprobe 88x2bu
-```
+If you want to have the driver available at startup, it will you convenient to
+register it in DKMS. This can be done completely automatically with the script
+`deploy.sh`.
 
 ## Raspberry Pi Access Point
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function ensure_no_cli_args() {
+    if [ $# -ne 0 ]
+    then
+        echo "No command line arguments accepted!" >&2
+        exit 1
+    fi
+}
+
+function ensure_root_permissions() {
+    if ! sudo -v
+    then
+        echo "Root permissions required to deploy the driver!" >&2
+        exit 1
+    fi
+}
+
+function get_version() {
+    sed -En 's/PACKAGE_VERSION="(.*)"/\1/p' dkms.conf
+}
+
+function deploy_driver() {
+    VER=$(get_version)
+    sudo rsync --delete --exclude=.git -rvhP ./ "/usr/src/rtl88x2bu-${VER}"
+    for action in add build install
+    do
+      sudo dkms "${action}" -m rtl88x2bu -v "${VER}"
+    done
+    sudo modprobe 88x2bu
+}
+
+ensure_no_cli_args
+ensure_root_permissions
+deploy_driver


### PR DESCRIPTION
A `deploy.sh` script, similar to the build.sh in 5.6.1_... is added. The main difference is that this script rejects command line arguments and uses some self-documenting functions.

The readme now has a section explaining how to test the driver on-the-fly. It also refers to `deploy.sh` for actual installation.