### PR TITLE
Support for network namespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ CONFIG_GSPI_HCI = n
 CONFIG_LED_CONTROL = y
 CONFIG_LED_ENABLE = y
 ########################## Features ###########################
+CONFIG_NET_NS=y
 CONFIG_MP_INCLUDED = y
 CONFIG_POWER_SAVING = y
 CONFIG_USB_AUTOSUSPEND = n

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -9322,6 +9322,9 @@ static void rtw_cfg80211_preinit_wiphy(_adapter *adapter, struct wiphy *wiphy)
 #endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 3, 0))
+#if defined(CONFIG_NET_NS)
+    wiphy->flags |= WIPHY_FLAG_NETNS_OK;
+#endif //CONFIG_NET_NS
 	wiphy->flags |= WIPHY_FLAG_HAS_REMAIN_ON_CHANNEL;
 	wiphy->flags |= WIPHY_FLAG_HAVE_AP_SME;
 	/* remove WIPHY_FLAG_OFFCHAN_TX, because we not support this feature */

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1713,6 +1713,9 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 	rtw_init_netdev_name(ndev, name);
 
 	_rtw_memcpy(ndev->dev_addr, adapter_mac_addr(adapter), ETH_ALEN);
+#if defined(CONFIG_NET_NS)
+    dev_net_set(ndev, wiphy_net(adapter_to_wiphy(adapter)));
+#endif //CONFIG_NET_NS
 
 	/* Tell the network stack we exist */
 


### PR DESCRIPTION
- Make configuration parameter (CONFIG_NET_NS)
- Add WIPHY_FLAG_NETNS_OK if linux kernel >= 3.3.0

Tested on Linux 5.7.0 with TP-Link Archer T4U v3.
