### PR TITLE
fix compilation issue caused by mismatched enum types

### DIFF
--- a/hal/led/hal_led.c
+++ b/hal/led/hal_led.c
@@ -63,7 +63,7 @@ void rtw_led_set_strategy(_adapter *adapter, u8 strategy)
 	rtw_hal_sw_led_deinit(pri_adapter);
 #endif
 
-	rtw_led_control(pri_adapter, RTW_LED_OFF);
+	rtw_led_control(pri_adapter, LED_CTL_LINK);
 }
 
 #ifdef CONFIG_RTW_SW_LED

--- a/hal/phydm/phydm_ccx.c
+++ b/hal/phydm/phydm_ccx.c
@@ -1364,7 +1364,7 @@ u8 phydm_clm_mntr_set(void *dm_void, struct clm_para_info *clm_para)
 		return PHYDM_SET_FAIL;
 	}
 
-	if (phydm_clm_racing_ctrl(dm, clm_para->clm_lv) == PHYDM_SET_FAIL)
+	if (phydm_clm_racing_ctrl(dm, (enum phydm_nhm_level) clm_para->clm_lv) == PHYDM_SET_FAIL)
 		return PHYDM_SET_FAIL;
 
 	if (clm_para->mntr_time >= 262)


### PR DESCRIPTION
```
$ uname -a
Linux sys-net 4.19.147-1.pvops.qubes.x86_64 #1 SMP Thu Oct 1 01:33:22 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux 
```

The driver's DKMS build failed due to the wrong enum types passed in as function parameters.

These 2 fixes allow the build to succeed, the driver still works (I'm using it right now to submit this PR) - I made sure that the new enums work out to the same `int` values as the old enums, so from a machine code perspective, nothing should be changed. Beyond that, I'm afraid I have no idea what I did.

It may be good to look into why this typing error happened as usually that's a symptom of a larger bug. I'm afraid that's a bit outside of my personal capabilities.

Happy to implement the fix differently if you have any suggestions