### PR TITLE
Build script repair sudo check

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 VER="$(sed -En 's/^PACKAGE_VERSION="(.*)"/\1/p' dkms.conf)"
 DRV_NAME=rtl88x2bu
 
-if ! sudo -v
+if [ "$EUID" -ne 0 ]
 then
     echo "Root privileges required to run this script!" >&2
     exit 1


### PR DESCRIPTION
The check for `sudo` should be done by comparing `$EUID` to 0 and not running
`sudo -v`.  `sudo -v` only refreshes the cache and returns true for
all users.

https://askubuntu.com/a/15856/100576

Also, because the script is executable, mark it as such.  This will make it less likely that users call `source ./build.sh`, which will fail and also exit their terminal.