### PR TITLE
resolve -Werror=misleading-indentation warning for gcc-11.

### DIFF
--- a/core/efuse/rtw_efuse.c
+++ b/core/efuse/rtw_efuse.c
@@ -904,10 +904,10 @@ void rtw_efuse_analyze(PADAPTER	padapter, u8 Type, u8 Fake)
 	for (i = 0; i < mapLen; i++) {
 		if (i % 16 == 0)
 			RTW_PRINT_SEL(RTW_DBGDUMP, "0x%03x: ", i);
-			_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
-				, pEfuseHal->fakeEfuseInitMap[i]
-				, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
-			);
+		_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
+			, pEfuseHal->fakeEfuseInitMap[i]
+			, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
+		);
 		}
 	_RTW_PRINT_SEL(RTW_DBGDUMP, "\n");
 

--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -3454,7 +3454,7 @@ void rtw_drv_scan_by_self(_adapter *padapter, u8 reason)
 		else
 		#endif
 			RTW_INFO(FUNC_ADPT_FMT" exit BusyTraffic\n", FUNC_ADPT_ARG(padapter));
-			goto exit;
+		goto exit;
 	}
 	else if (ssc_chk != SS_ALLOW)
 		goto exit;

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -3576,7 +3576,7 @@ int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
 			for (i = 0; i < precv_frame->u.hdr.len; i = i + 8)
 				RTW_INFO("%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:\n", *(ptr + i),
 					*(ptr + i + 1), *(ptr + i + 2) , *(ptr + i + 3) , *(ptr + i + 4), *(ptr + i + 5), *(ptr + i + 6), *(ptr + i + 7));
-				RTW_INFO("#############################\n");
+			RTW_INFO("#############################\n");
 				_rtw_memset(pmppriv->mplink_buf, '\0' , sizeof(pmppriv->mplink_buf));
 				_rtw_memcpy(pmppriv->mplink_buf, ptr, precv_frame->u.hdr.len);
 				pmppriv->mplink_rx_len = precv_frame->u.hdr.len;


### PR DESCRIPTION
When compiling with gcc11, we will be warned by "-Werror=misleading-indentation".
This branch is using "EXTRA_CFLAGS + = -Werror" in makefile need to resolve warnings for compilation.