### PR TITLE
Implement github actions to build over last kernels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build
+
+on: [pull_request]
+
+jobs:
+
+  commontasks:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Avoid 0x0BDA
+      #Find devices that not use 0x0BDA instead of const USB_VENDOR_ID_REALTEK
+      run: grep -c -i "0x0BDA" os_dep/linux/usb_intf.c | grep -w 1
+    - name: Find duplicates
+      #Find devices that not use 0x0BDA instead of const USB_VENDOR_ID_REALTEK
+      run: grep -i "{USB_DEVICE(" os_dep/linux/usb_intf.c | cut -d ')' -f1 | sort | uniq -cd | wc -c | grep -w 0
+    - name: Get kernel matrix
+      id: set-matrix
+      run: |
+        JSON=$(curl -s https://www.kernel.org/releases.json)
+        VERSIONSARRAY=$(echo $JSON | jq -c '[.releases[] | {version: .version, moniker: .moniker} | select(.moniker != "linux-next") | .version]')
+        echo ::set-output name=matrix::${VERSIONSARRAY}
+
+  build:
+    needs: commontasks
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: 
+        version: ${{fromJson(needs.commontasks.outputs.matrix)}}
+        #version: [4.9.248, 4.4.248]
+    steps:
+    - name: install deb packages
+      env: 
+        VERSION: ${{matrix.version }}
+      run: |
+        KERNEL_URL=https://kernel.ubuntu.com/~kernel-ppa/mainline/
+        KERNEL_URL_DETAILS=$(wget --quiet -O - ${KERNEL_URL}v${VERSION}/ | grep -A8 "Build for amd64\|Test amd64")
+        ALL_DEB=$(echo "$KERNEL_URL_DETAILS" |  grep -m1 'all.deb' | cut -d '"' -f 2)
+        AMD64_DEB=$(echo "$KERNEL_URL_DETAILS" | grep -m1 "amd64.deb" | cut -d '"' -f 2)
+        [  -z "$ALL_DEB" ] && exit 1
+        [  -z "$AMD64_DEB" ] && exit 2
+        wget -nv ${KERNEL_URL}v${VERSION}/$AMD64_DEB
+        wget -nv ${KERNEL_URL}v${VERSION}/$ALL_DEB
+        sudo dpkg --force-all -i *.deb
+        echo "KVER=$(echo $ALL_DEB | cut -d '_' -f 2 | rev | cut -c14- | rev)-generic" >> $GITHUB_ENV
+    - uses: actions/checkout@v2
+    - name: build
+      run: make KVER=$KVER


### PR DESCRIPTION
Automated build over last kernel versions.

Version numbers are fetch from https://www.kernel.org/
Compiled kernel and headers from https://kernel.ubuntu.com/~kernel-ppa/mainline/
Note that sometimes kernels from kernel-ppa fails so github action will also fails.
