### PR TITLE
enable 802.11ac for ap mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ CONFIG_RTW_CHPLAN = 0xFF
 CONFIG_RTW_ADAPTIVITY_EN = disable
 CONFIG_RTW_ADAPTIVITY_MODE = normal
 CONFIG_SIGNAL_SCALE_MAPPING = n
+CONFIG_80211D = y
 CONFIG_80211W = y
 CONFIG_REDUCE_TX_CPU_LOADING = n
 CONFIG_BR_EXT = y
@@ -84,7 +85,7 @@ CONFIG_ICMP_VOQ = n
 CONFIG_IP_R_MONITOR = n #arp VOQ and high rate
 # user priority mapping rule : tos, dscp
 CONFIG_RTW_UP_MAPPING_RULE = tos
-# Enable VHT rate on 2.4G channel or not
+# enable VHT rate on 2.4G channel or not
 CONFIG_RTW_VHT_2G4 = y
 
 ########################## Debug ###########################
@@ -1133,6 +1134,10 @@ endif
 
 ifeq ($(CONFIG_SIGNAL_SCALE_MAPPING), y)
 EXTRA_CFLAGS += -DCONFIG_SIGNAL_SCALE_MAPPING
+endif
+
+ifeq ($(CONFIG_80211D), y)
+EXTRA_CFLAGS += -DCONFIG_80211D
 endif
 
 ifeq ($(CONFIG_80211W), y)

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -305,7 +305,7 @@ int rtw_bfee_rf_number = 0; /*BeamformeeCapRfNum  Rf path number, 0 for auto, ot
 #endif /* CONFIG_80211N_HT */
 
 #ifdef CONFIG_80211AC_VHT
-int rtw_vht_enable = 1; /* 0:disable, 1:enable, 2:force auto enable */
+int rtw_vht_enable = 2; /* 0:disable, 1:enable, 2:force auto enable */
 module_param(rtw_vht_enable, int, 0644);
 
 int rtw_ampdu_factor = 7;


### PR DESCRIPTION
this patch enables support for 802.11ac mode when using the wireless card as an ap, or we can use up to 802.11n only