### PR TITLE
Fix compilation failure when specific option is not set

### DIFF
--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -3455,7 +3455,9 @@ void rtw_drv_scan_by_self(_adapter *padapter, u8 reason)
 		#endif
 			RTW_INFO(FUNC_ADPT_FMT" exit BusyTraffic\n", FUNC_ADPT_ARG(padapter));
 			goto exit;
+		#ifdef CONFIG_LAYER2_ROAMING
 		}
+		#endif
 	}
 	else if (ssc_chk != SS_ALLOW)
 		goto exit;


### PR DESCRIPTION
If the option CONFIG_LAYER2_ROAMING is unset, at the changed location a
closing brace without correct counterpart is inserted. This would break
the compilation. Now that brace is guarded by a preprocessor directive.