### PR TITLE
Use nproc to build driver using multithreads

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,6 +1,7 @@
 PACKAGE_NAME="rtl88x2bu"
 PACKAGE_VERSION="5.8.7.1"
-MAKE[0]="'make' KVER=$kernelver src=$source_tree/rtl88x2bu-$PACKAGE_VERSION"
+PROCS_NUM="$(nproc)"
+MAKE[0]="'make' -j $PROCS_NUM KVER=$kernelver src=$source_tree/rtl88x2bu-$PACKAGE_VERSION"
 CLEAN="make clean"
 BUILT_MODULE_NAME[0]="88x2bu"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/net"


### PR DESCRIPTION
Recent computers including single board computers have many cores available.

This reduces compile time significantly when installing the new driver for the kernel.