### PR TITLE
Improved documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,32 @@ modules:
     sudo dkms remove rtl88x2bu/5.8.7.4 --all
     find /lib/modules -name cfg80211.ko -ls
     sudo rm -f /lib/modules/*/updates/net/wireless/cfg80211.ko
-    
-    
+
+
 This can also be caused by cfg80211 module not being present in the kernel.
 You can remedy this by running:
 
     sudo modprobe cfg80211
+
+### Linux 5.18+ and RTW88 Driver
+
+Starting from Linux 5.18, some distributions have added experimental RTW88 USB
+support (include RTW88x2BU support). It is not yet stable but if it works well
+on your system, then you no longer need this driver. But if it doesn't work or
+is unstable, you need to manually blacklist it because it has a higher loading
+priority than this external drivers.
+
+Check the currently loaded module using `lsmod`. If you see `rtw88_core`,
+`rtw88_usb`, or any name beginning with `rtw88_` then you are using the RTW88
+driver. If you see `88x2bu` then you are using this RTW88x2BU driver.
+
+To blacklist RTW88 8822bu USB driver, run the following command:
+
+```
+echo "blacklist rtw88_8822bu" > /etc/modprobe.d/rtw8822bu.conf
+```
+
+And reboot your system.
 
 
 ## Raspberry Pi Access Point

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ register it in DKMS. An executable explanation of how to do so can be found in
 the script `deploy.sh`. Since registering a kernel module in DKMS is a major
 intervention, only execute it if you understand what the script does.
 
-### Known Problems
+### Unknown Symbol Errors
 
 Some users reported problems due to `Unknown symbol in module`. This can be
 caused by old deployments of the driver still being present in the systems


### PR DESCRIPTION
I copied over a section of [RinCat's](https://github.com/RinCat/RTL88x2BU-Linux-Driver/) README, explaining how to deal with RTW88. This PR exists mainly to enable RinCat to approve copying that section.