### PR TITLE
Fix compilation for CentOS 9 Stream

### DIFF
--- a/include/basic_types.h
+++ b/include/basic_types.h
@@ -80,6 +80,11 @@
 
 	typedef	signed int sint;
 
+	#ifndef RHEL_RELEASE_CODE
+	#define RHEL_RELEASE_VERSION(a,b) (((a) << 8) + (b))
+	#define RHEL_RELEASE_CODE 0
+	#endif
+
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 19))
 typedef _Bool bool;
 

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -34,7 +34,7 @@ inline struct proc_dir_entry *get_rtw_drv_proc(void)
 #define file_inode(file) ((file)->f_dentry->d_inode)
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0))
 #define PDE_DATA(inode) pde_data((inode))
 #elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 10, 0))
 #define PDE_DATA(inode) PDE((inode))->data

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -34,7 +34,7 @@ inline struct proc_dir_entry *get_rtw_drv_proc(void)
 #define file_inode(file) ((file)->f_dentry->d_inode)
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)) || (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,0))
 #define PDE_DATA(inode) pde_data((inode))
 #elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 10, 0))
 #define PDE_DATA(inode) PDE((inode))->data


### PR DESCRIPTION
Fix dkms compilation for CentOS 9 Stream.

Additional details:
```
dhuertas@localhost rtl88x2bu]$ cat /etc/centos-release 
CentOS Stream release 9
[dhuertas@localhost rtl88x2bu]$ uname -a
Linux localhost.localdomain 5.14.0-160.el9.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Aug 25 23:06:03 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
[dhuertas@localhost rtl88x2bu]$ lsusb -s 3:2
Bus 003 Device 002: ID 2357:0138 TP-Link 802.11ac NIC
[dhuertas@localhost rtl88x2bu]$ lsmod | grep 88x2bu
88x2bu               2813952  0
cfg80211             1052672  1 88x2bu
[dhuertas@localhost rtl88x2bu]$ nmcli
wlp6s0u1: connected to XXXXXXXXXXXXXXXXXX
        "TP-Link Wi-Fi"
        wifi (rtl88x2bu), XX:XX:XX:XX:XX:XX, hw, mtu 1500
        ip4 default
        inet4 192.168.1.45/24
        route4 192.168.1.0/24 metric 600
        route4 default via 192.168.1.1 metric 600
        inet6 fe80::6700:52fb:bbc5:49f1/64
        route6 fe80::/64 metric 1024
```