### PR TITLE
Removing unused variables

### DIFF
--- a/core/efuse/rtw_efuse.c
+++ b/core/efuse/rtw_efuse.c
@@ -58,8 +58,6 @@ BOOLEAN rtw_file_efuse_IsMasked(PADAPTER pAdapter, u16 Offset, u8 *maskbuf)
 }
 BOOLEAN efuse_IsBT_Masked(PADAPTER pAdapter, u16 Offset)
 {
-	PHAL_DATA_TYPE pHalData = GET_HAL_DATA(pAdapter);
-
 	if (pAdapter->registrypriv.boffefusemask)
 		return FALSE;
 
@@ -82,8 +80,6 @@ BOOLEAN efuse_IsBT_Masked(PADAPTER pAdapter, u16 Offset)
 
 void rtw_bt_efuse_mask_array(PADAPTER pAdapter, u8 *pArray)
 {
-	PHAL_DATA_TYPE pHalData = GET_HAL_DATA(pAdapter);
-
 #ifdef CONFIG_BT_EFUSE_MASK
 #ifdef CONFIG_USB_HCI
 if (IS_HARDWARE_TYPE_8822CU(pAdapter))
@@ -103,8 +99,6 @@ if (IS_HARDWARE_TYPE_8822CU(pAdapter))
 
 u16 rtw_get_bt_efuse_mask_arraylen(PADAPTER pAdapter)
 {
-	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(pAdapter);
-
 #ifdef CONFIG_BT_EFUSE_MASK
 #ifdef CONFIG_USB_HCI
 	if (IS_HARDWARE_TYPE_8822CU(pAdapter))
@@ -1184,7 +1178,7 @@ u8 rtw_efuse_map_read(PADAPTER adapter, u16 addr, u16 cnts, u8 *data)
 {
 	struct dvobj_priv *d;
 	u8 *efuse = NULL;
-	u32 size, i;
+	u32 size;
 	int err;
 	u32	backupRegs[4] = {0};
 	u8 status = _SUCCESS;
@@ -1565,8 +1559,6 @@ void hal_ReadEFuse_BT_logic_map(
 	u8			*pbuf
 )
 {
-
-	PHAL_DATA_TYPE	pHalData = GET_HAL_DATA(padapter);
 
 	u8	*efuseTbl, *phyefuse;
 	u8	bank;

--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -1628,7 +1628,6 @@ void start_bss_network(_adapter *padapter, struct createbss_parm *parm)
 	u8 mlme_act = MLME_ACTION_UNKNOWN;
 	u8 val8;
 	u16 bcn_interval;
-	u32	acparm;
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
 	struct mlme_priv *pmlmepriv = &(padapter->mlmepriv);
 	struct security_priv *psecuritypriv = &(padapter->securitypriv);
@@ -4569,7 +4568,6 @@ u8 rtw_ap_chbw_decision(_adapter *adapter, u8 ifbmp, u8 excl_ifbmp
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	RT_CHANNEL_INFO *chset = adapter_to_chset(adapter);
-	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
 	bool ch_avail = _FALSE;
 	u8 cur_ie_ch[CONFIG_IFACE_NUMBER] = {0};
 	u8 cur_ie_bw[CONFIG_IFACE_NUMBER] = {0};

--- a/core/rtw_beamforming.c
+++ b/core/rtw_beamforming.c
@@ -33,7 +33,6 @@ static void _get_txvector_parameter(PADAPTER adapter, struct sta_info *sta, u8 *
 	u16 aid;
 	u8 *bssid;
 	u16 val16;
-	u8 i;
 
 
 	mlme = &adapter->mlmepriv;
@@ -170,9 +169,7 @@ static u8 _send_ht_ndpa_packet(PADAPTER adapter, u8 *ra, enum channel_width bw)
 	struct mlme_ext_info		*pmlmeinfo;
 	struct xmit_frame		*pmgntframe;
 	/* Beamforming */
-	struct beamforming_info		*info;
 	struct beamformee_entry		*bfee;
-	struct ndpa_sta_info		sta_info;
 	u8 ActionHdr[4] = {ACT_CAT_VENDOR, 0x00, 0xE0, 0x4C};
 	/* MISC */
 	struct pkt_attrib		*attrib;
@@ -715,8 +712,6 @@ static void _sounding_handler(PADAPTER adapter)
 	struct sounding_info *sounding;
 	struct beamformee_entry *bfee;
 	u8 su_idx, i;
-	u32 timeout_period = 0;
-	u8 set_timer = _FALSE;
 	int ret = 0;
 	static u16 wait_cnt = 0;
 
@@ -1000,8 +995,6 @@ static struct beamformer_entry *_bfer_add_entry(PADAPTER adapter,
 	struct mlme_priv *mlme;
 	struct beamforming_info *info;
 	struct beamformer_entry *bfer;
-	u8 *bssid;
-	u16 val16;
 	u8 i;
 
 
@@ -1185,8 +1178,6 @@ static struct beamformee_entry *_bfee_add_entry(PADAPTER adapter,
 	struct mlme_priv *mlme;
 	struct beamforming_info *info;
 	struct beamformee_entry *bfee;
-	u8 *bssid;
-	u16 val16;
 	u8 i;
 
 
@@ -1460,7 +1451,6 @@ static void _beamforming_leave(PADAPTER adapter, u8 *ra)
 	struct beamforming_info *info;
 	struct beamformer_entry *bfer = NULL;
 	struct beamformee_entry *bfee = NULL;
-	u8 bHwStateAddInit = _FALSE;
 
 
 	RTW_INFO("+%s\n", __FUNCTION__);

--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -6078,20 +6078,9 @@ ssize_t proc_set_tx_auth(struct file *file, const char __user *buffer, size_t co
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	struct mlme_ext_priv	*pmlmeext = &padapter->mlmeextpriv;
-	struct mlme_ext_info	*pmlmeinfo = &(pmlmeext->mlmext_info);
 	struct mlme_priv *pmlmepriv = &(padapter->mlmepriv);
-	struct	sta_priv *pstapriv = &padapter->stapriv;
-	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
-	struct macid_ctl_t *macid_ctl = dvobj_to_macidctl(dvobj);
-	struct sta_info *psta;
-	_list	*plist, *phead;
-	_irqL	 irqL;
 	char tmp[16];
-	u8	mac_addr[NUM_STA][ETH_ALEN];
-	u8 bc_addr[ETH_ALEN] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 	u32 tx_auth;
-	u8 index;
 
 
 	if (count > 2) {

--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -1563,7 +1563,9 @@ exit:
 void rtw_surveydone_event_callback(_adapter	*adapter, u8 *pbuf)
 {
 	_irqL  irqL;
+#ifdef CONFIG_RTW_ACS
 	struct surveydone_event *parm = (struct surveydone_event *)pbuf;
+#endif
 	struct	mlme_priv	*pmlmepriv = &(adapter->mlmepriv);
 #ifdef CONFIG_RTW_80211R
 	struct mlme_ext_priv	*pmlmeext = &adapter->mlmeextpriv;

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -393,7 +393,6 @@ bool _rtw_rfctl_overlap_radar_detect_ch(struct rf_ctl_t *rfctl, u8 ch, u8 bw, u8
 	bool ret = _FALSE;
 	u32 hi = 0, lo = 0;
 	u32 r_hi = 0, r_lo = 0;
-	int i;
 
 	if (rfctl->radar_detect_by_others)
 		goto exit;
@@ -549,7 +548,6 @@ inline void rtw_chset_update_non_ocp_ms(RT_CHANNEL_INFO *ch_set, u8 ch, u8 bw, u
 
 u32 rtw_get_ch_waiting_ms(struct rf_ctl_t *rfctl, u8 ch, u8 bw, u8 offset, u32 *r_non_ocp_ms, u32 *r_cac_ms)
 {
-	struct dvobj_priv *dvobj = rfctl_to_dvobj(rfctl);
 	u32 non_ocp_ms;
 	u32 cac_ms;
 	u8 in_rd_range = 0; /* if in current radar detection range*/
@@ -7277,10 +7275,8 @@ unsigned int OnAction_sa_query(_adapter *padapter, union recv_frame *precv_frame
 {
 	u8 *pframe = precv_frame->u.hdr.rx_data;
 	struct rx_pkt_attrib *pattrib = &precv_frame->u.hdr.attrib;
-	struct mlme_ext_priv	*pmlmeext = &(padapter->mlmeextpriv);
 	struct sta_info		*psta;
 	struct sta_priv		*pstapriv = &padapter->stapriv;
-	struct mlme_priv *pmlmepriv = &(padapter->mlmepriv);
 	u16 tid;
 	/* Baron */
 
@@ -9998,7 +9994,6 @@ void issue_action_spct_ch_switch(_adapter *padapter, u8 *ra, u8 new_ch, u8 ch_of
 void issue_action_SA_Query(_adapter *padapter, unsigned char *raddr, unsigned char action, unsigned short tid, u8 key_type)
 {
 	u8	category = RTW_WLAN_CATEGORY_SA_QUERY;
-	u16	reason_code;
 	struct xmit_frame		*pmgntframe;
 	struct pkt_attrib		*pattrib;
 	u8					*pframe;
@@ -10009,8 +10004,6 @@ void issue_action_SA_Query(_adapter *padapter, unsigned char *raddr, unsigned ch
 	struct mlme_ext_info	*pmlmeinfo = &(pmlmeext->mlmext_info);
 	struct sta_info		*psta;
 	struct sta_priv		*pstapriv = &padapter->stapriv;
-	struct registry_priv		*pregpriv = &padapter->registrypriv;
-	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
 
 	if (rtw_rfctl_is_tx_blocked_by_ch_waiting(adapter_to_rfctl(padapter)))
 		return;
@@ -13068,8 +13061,6 @@ void sa_query_timer_hdl(void *ctx)
 {
 	struct sta_info *psta = (struct sta_info *)ctx;
 	_adapter *padapter = psta->padapter;
-	_irqL irqL;
-	struct sta_priv *pstapriv = &padapter->stapriv;
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
 
 	if (check_fwstate(pmlmepriv, WIFI_STATION_STATE) == _TRUE &&

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -189,7 +189,9 @@ void rtw_txpwr_init_regd(struct rf_ctl_t *rfctl)
 		, rfctl->country_ent ? rfctl->country_ent->alpha2 : NULL
 		, rfctl->ChannelPlan);
 	if (exc) {
+#ifdef CONFIG_RTW_DEBUG
 		u8 has_country = (exc->country[0] == '\0' && exc->country[1] == '\0') ? 0 : 1;
+#endif
 
 		if (strcmp(exc->regd_name, regd_str(TXPWR_LMT_NONE)) == 0)
 			rfctl->regd_name = regd_str(TXPWR_LMT_NONE);
@@ -6163,7 +6165,9 @@ int issue_probereq_p2p_ex(_adapter *adapter, u8 *da, int try_cnt, int wait_ms)
 {
 	int ret;
 	int i = 0;
+#ifdef CONFIG_RTW_DEBUG
 	systime start = rtw_get_current_time();
+#endif
 
 	do {
 		ret = _issue_probereq_p2p(adapter, da, wait_ms > 0 ? _TRUE : _FALSE);
@@ -8564,7 +8568,9 @@ int issue_probereq_ex(_adapter *padapter, const NDIS_802_11_SSID *pssid, const u
 {
 	int ret = _FAIL;
 	int i = 0;
+#ifdef CONFIG_RTW_DEBUG
 	systime start = rtw_get_current_time();
+#endif
 
 	if (rtw_rfctl_is_tx_blocked_by_ch_waiting(adapter_to_rfctl(padapter)))
 		goto exit;
@@ -9593,7 +9599,9 @@ int issue_nulldata(_adapter *padapter, unsigned char *da, unsigned int power_mod
 {
 	int ret = _FAIL;
 	int i = 0;
+#ifdef CONFIG_RTW_DEBUG
 	systime start = rtw_get_current_time();
+#endif
 	struct mlme_ext_priv	*pmlmeext = &(padapter->mlmeextpriv);
 	struct mlme_ext_info	*pmlmeinfo = &(pmlmeext->mlmext_info);
 
@@ -9747,7 +9755,9 @@ int issue_qos_nulldata(_adapter *padapter, unsigned char *da, u16 tid, u8 ps, in
 {
 	int ret = _FAIL;
 	int i = 0;
+#ifdef CONFIG_RTW_DEBUG
 	systime start = rtw_get_current_time();
+#endif
 	struct mlme_ext_priv	*pmlmeext = &(padapter->mlmeextpriv);
 	struct mlme_ext_info	*pmlmeinfo = &(pmlmeext->mlmext_info);
 
@@ -9888,7 +9898,9 @@ int issue_deauth_ex(_adapter *padapter, u8 *da, unsigned short reason, int try_c
 {
 	int ret = _FAIL;
 	int i = 0;
+#ifdef CONFIG_RTW_DEBUG
 	systime start = rtw_get_current_time();
+#endif
 
 	if (rtw_rfctl_is_tx_blocked_by_ch_waiting(adapter_to_rfctl(padapter)))
 		goto exit;
@@ -10301,7 +10313,9 @@ inline u8 issue_addba_rsp_wait_ack(_adapter *adapter, unsigned char *ra, u8 tid,
 {
 	int ret = _FAIL;
 	int i = 0;
+#ifdef CONFIG_RTW_DEBUG
 	systime start = rtw_get_current_time();
+#endif
 
 	if (rtw_rfctl_is_tx_blocked_by_ch_waiting(adapter_to_rfctl(adapter)))
 		goto exit;
@@ -10379,7 +10393,9 @@ int issue_del_ba_ex(_adapter *adapter, unsigned char *ra, u8 tid, u16 reason, u8
 {
 	int ret = _FAIL;
 	int i = 0;
+#ifdef CONFIG_RTW_DEBUG
 	systime start = rtw_get_current_time();
+#endif
 
 	if (rtw_rfctl_is_tx_blocked_by_ch_waiting(adapter_to_rfctl(adapter)))
 		goto exit;
@@ -10657,7 +10673,9 @@ int issue_action_SM_PS_wait_ack(_adapter *padapter, unsigned char *raddr, u8 New
 {
 	int ret = _FAIL;
 	int i = 0;
+#ifdef CONFIG_RTW_DEBUG
 	systime start = rtw_get_current_time();
+#endif
 
 	if (rtw_rfctl_is_tx_blocked_by_ch_waiting(adapter_to_rfctl(padapter)))
 		goto exit;

--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -349,8 +349,6 @@ void mpt_InitHWConfig(PADAPTER Adapter)
 
 #ifdef CONFIG_RTL8822B
 	else if (IS_HARDWARE_TYPE_8822B(Adapter)) {
-		u32 tmp_reg = 0;
-
 		PlatformEFIOWrite2Byte(Adapter, REG_RXFLTMAP1_8822B, 0x2000);
 		/* fixed wifi can't 2.4g tx suggest by Szuyitasi 20160504 */
 		phy_set_bb_reg(Adapter, 0x70, bMaskByte3, 0x0e);
@@ -2403,7 +2401,6 @@ static u32 rtw_GetPSDData(PADAPTER pAdapter, u32 point)
  */
 u32 mp_query_psd(PADAPTER pAdapter, u8 *data)
 {
-	HAL_DATA_TYPE	*pHalData	= GET_HAL_DATA(pAdapter);
 	struct dm_struct *p_dm = adapter_to_phydm(pAdapter);
 
 	u32 i, psd_pts = 0, psd_start = 0, psd_stop = 0;

--- a/core/rtw_odm.c
+++ b/core/rtw_odm.c
@@ -216,7 +216,9 @@ void rtw_odm_parse_rx_phy_status_chinfo(union recv_frame *rframe, u8 *phys)
 	_adapter *adapter = rframe->u.hdr.adapter;
 	struct dm_struct *phydm = adapter_to_phydm(adapter);
 	struct rx_pkt_attrib *attrib = &rframe->u.hdr.attrib;
+	#ifdef CONFIG_RTW_DEBUG
 	u8 *wlanhdr = get_recvframe_data(rframe);
+	#endif
 
 	if (phydm->support_ic_type & PHYSTS_2ND_TYPE_IC) {
 		/*
@@ -247,7 +249,9 @@ void rtw_odm_parse_rx_phy_status_chinfo(union recv_frame *rframe, u8 *phys)
 		*/
 
 		if ((*phys & 0xf) == 0) {
+			#ifdef CONFIG_RTW_DEBUG
 			struct phy_sts_rpt_jgr2_type0 *phys_t0 = (struct phy_sts_rpt_jgr2_type0 *)phys;
+			#endif
 
 			if (DBG_RX_PHYSTATUS_CHINFO) {
 				RTW_PRINT("phys_t%u ta="MAC_FMT" %s, %s(band:%u, ch:%u, l_rxsc:%u)\n"
@@ -375,7 +379,9 @@ type1_end:
 				attrib->ch = pkt_cch;
 
 		} else {
+			#ifdef CONFIG_RTW_DEBUG
 			struct phy_sts_rpt_jgr2_type2 *phys_t2 = (struct phy_sts_rpt_jgr2_type2 *)phys;
+			#endif
 
 			if (DBG_RX_PHYSTATUS_CHINFO) {
 				RTW_PRINT("phys_t%u ta="MAC_FMT" %s, %s(band:%u, ch:%u, l_rxsc:%u, ht_rxsc:%u)\n"

--- a/core/rtw_pwrctrl.c
+++ b/core/rtw_pwrctrl.c
@@ -278,7 +278,9 @@ exit:
 void rtw_ps_processor(_adapter *padapter)
 {
 	struct pwrctrl_priv *pwrpriv = adapter_to_pwrctl(padapter);
+#ifdef CONFIG_RTW_DEBUG
 	struct mlme_priv *pmlmepriv = &(padapter->mlmepriv);
+#endif
 	struct dvobj_priv *psdpriv = padapter->dvobj;
 	struct debug_priv *pdbgpriv = &psdpriv->drv_dbg;
 #ifdef SUPPORT_HW_RFOFF_DETECTED

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -855,7 +855,11 @@ sint recv_decache(union recv_frame *precv_frame)
 {
 	struct sta_info *psta = precv_frame->u.hdr.psta;
 	struct rx_pkt_attrib *pattrib = &precv_frame->u.hdr.attrib;
+#ifdef CONFIG_RTW_DEBUG
+#if defined(DBG_RX_SEQ) || defined(DBG_RX_DROP_FRAME)
 	_adapter *adapter = psta->padapter;
+#endif
+#endif
 	sint tid = pattrib->priority;
 	u16 seq_ctrl = ((precv_frame->u.hdr.attrib.seq_num & 0xffff) << 4) |
 		       (precv_frame->u.hdr.attrib.frag_num & 0xf);

--- a/core/rtw_security.c
+++ b/core/rtw_security.c
@@ -2038,7 +2038,7 @@ u32	rtw_BIP_verify(_adapter *padapter, u8 *whdr_pos, sint flen
 {
 	u8 *BIP_AAD, *mme;
 	u32	res = _FAIL;
-	uint len, ori_len;
+	uint ori_len;
 	u16 pkt_keyid = 0;
 	u64 pkt_ipn = 0;
 	struct rtw_ieee80211_hdr *pwlanhdr;

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -2796,7 +2796,9 @@ void parsing_eapol_packet(_adapter *padapter, u8 *key_payload, struct sta_info *
 	struct ieee802_1x_hdr *hdr;
 	struct wpa_eapol_key *key;
 	u16 key_info, key_data_length;
+#ifdef CONFIG_RTW_DEBUG
 	char *trx_msg = trx_type ? "send" : "recv";
+#endif
 
 	hdr = (struct ieee802_1x_hdr *) key_payload;
 

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -2631,9 +2631,7 @@ exit:
 
 int rtw_check_bcn_info(ADAPTER *Adapter, u8 *pframe, u32 packet_len)
 {
-	u8 *pbssid = GetAddr3Ptr(pframe);
 	struct mlme_priv *pmlmepriv = &Adapter->mlmepriv;
-	struct wlan_network *cur_network = &(Adapter->mlmepriv.cur_network);
 	struct beacon_keys *cur_beacon = &pmlmepriv->cur_beacon_keys;
 	struct beacon_keys recv_beacon;
 	int ret = 0;

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -548,7 +548,6 @@ void rtw_get_adapter_tx_rate_bmp(_adapter *adapter, u16 r_bmp_cck_ofdm[], u32 r_
 	u16 bmp_cck_ofdm, tmp_cck_ofdm;
 	u32 bmp_ht, tmp_ht;
 	u64 bmp_vht, tmp_vht;
-	int i;
 
 	for (bw = CHANNEL_WIDTH_20; bw <= CHANNEL_WIDTH_160; bw++) {
 		bmp_cck_ofdm = bmp_ht = bmp_vht = 0;
@@ -2944,23 +2943,15 @@ s32 rtw_mgmt_xmitframe_coalesce(_adapter *padapter, _pkt *pkt, struct xmit_frame
 #define DBG_MGMT_XMIT_BIP_DUMP 0
 #define DBG_MGMT_XMIT_ENC_DUMP 0
 
-	struct pkt_file pktfile;
-	s32 frg_inx, frg_len, mpdu_len, llc_sz, mem_sz;
-	SIZE_PTR addr;
 	u8 *pframe, *mem_start = NULL, *tmp_buf = NULL;
-	u8 hw_hdr_offset, subtype ;
+	u8 subtype ;
 	u8 category = 0xFF;
 	struct sta_info		*psta = NULL;
-	struct xmit_priv	*pxmitpriv = &padapter->xmitpriv;
 	struct pkt_attrib	*pattrib = &pxmitframe->attrib;
-	u8 *pbuf_start;
 	s32 bmcst = IS_MCAST(pattrib->ra);
-	s32 res = _FAIL;
 	u8 *BIP_AAD = NULL;
 	u8 *MGMT_body = NULL;
 
-	struct mlme_ext_priv	*pmlmeext = &padapter->mlmeextpriv;
-	struct mlme_priv	*pmlmepriv = &padapter->mlmepriv;
 	struct rtw_ieee80211_hdr	*pwlanhdr;
 	u8 MME[_MME_IE_LENGTH_];
 

--- a/hal/btc/halbtc8822b1ant.c
+++ b/hal/btc/halbtc8822b1ant.c
@@ -162,8 +162,6 @@ halbtc8822b1ant_limited_tx(struct btc_coexist *btc, boolean force_exec,
 			   boolean tx_limit_en,  boolean ampdu_limit_en)
 {
 	struct coex_sta_8822b_1ant *coex_sta = &btc->coex_sta_8822b_1ant;
-	struct wifi_link_info_8822b_1ant *wifi_link_info_ext =
-					 &btc->wifi_link_info_8822b_1ant;
 	boolean wifi_under_b_mode = FALSE;
 
 	/* Force Max Tx retry limit = 8*/
@@ -536,8 +534,6 @@ static void halbtc8822b1ant_monitor_bt_ctr(struct btc_coexist *btc)
 	struct coex_sta_8822b_1ant *coex_sta = &btc->coex_sta_8822b_1ant;
 	u32 reg_hp_txrx, reg_lp_txrx, u32tmp;
 	u32 reg_hp_tx = 0, reg_hp_rx = 0, reg_lp_tx = 0, reg_lp_rx = 0;
-	static u8 num_of_bt_counter_chk, cnt_autoslot_hang;
-	struct btc_bt_link_info *bt_link_info = &btc->bt_link_info;
 
 	reg_hp_txrx = 0x770;
 	reg_lp_txrx = 0x774;
@@ -571,13 +567,10 @@ static void halbtc8822b1ant_monitor_bt_ctr(struct btc_coexist *btc)
 static void halbtc8822b1ant_monitor_wifi_ctr(struct btc_coexist *btc)
 {
 	struct coex_sta_8822b_1ant *coex_sta = &btc->coex_sta_8822b_1ant;
-	struct coex_dm_8822b_1ant *coex_dm = &btc->coex_dm_8822b_1ant;
 	boolean wifi_busy = FALSE, wifi_scan = FALSE;
 	static u8 wl_noisy_count0, wl_noisy_count1 = 3, wl_noisy_count2;
 	u32 cnt_cck;
 	static u8 cnt_ccklocking;
-	u8 h2c_parameter[1] = {0};
-	struct btc_bt_link_info *bt_link_info = &btc->bt_link_info;
 
 	btc->btc_get(btc, BTC_GET_BL_WIFI_BUSY, &wifi_busy);
 	btc->btc_get(btc, BTC_GET_BL_WIFI_SCAN, &wifi_scan);
@@ -722,7 +715,6 @@ halbtc8822b1ant_moniter_wifibt_status(struct btc_coexist *btc)
 	u32 num_of_wifi_link = 0, wifi_link_mode = 0;
 	static u32 pre_num_of_wifi_link, pre_wifi_link_mode;
 	boolean miracast_plus_bt = FALSE;
-	u8 lna_lvl = 1;
 
 	btc->btc_get(btc, BTC_GET_BL_WIFI_CONNECTED, &wifi_connected);
 	btc->btc_get(btc, BTC_GET_BL_WIFI_BUSY, &wifi_busy);
@@ -1323,7 +1315,6 @@ static void halbtc8822b1ant_update_bt_link_info(struct btc_coexist *btc)
 static void
 halbtc8822b1ant_update_wifi_ch_info(struct btc_coexist *btc, u8 type)
 {
-	struct coex_sta_8822b_1ant *coex_sta = &btc->coex_sta_8822b_1ant;
 	struct coex_dm_8822b_1ant *coex_dm = &btc->coex_dm_8822b_1ant;
 	struct wifi_link_info_8822b_1ant *wifi_link_info_ext =
 					 &btc->wifi_link_info_8822b_1ant;
@@ -1520,8 +1511,6 @@ halbtc8822b1ant_wait_indirect_reg_ready(struct btc_coexist *btc)
 static
 u32 halbtc8822b1ant_read_indirect_reg(struct btc_coexist *btc, u16 reg_addr)
 {
-	u32 delay_count = 0;
-
 	/* wait for ready bit before access 0x1700 */
 	halbtc8822b1ant_wait_indirect_reg_ready(btc);
 
@@ -1533,7 +1522,7 @@ static
 void halbtc8822b1ant_write_indirect_reg(struct btc_coexist *btc, u16 reg_addr,
 					u32 bit_mask, u32 reg_value)
 {
-	u32 val, i = 0, bitpos = 0, delay_count = 0;
+	u32 val, i = 0, bitpos = 0;
 
 	if (bit_mask == 0x0)
 		return;
@@ -2055,7 +2044,6 @@ void halbtc8822b1ant_set_tdma(struct btc_coexist *btc, u8 byte1,
 	u8 h2c_parameter[5] = {0};
 	u8 real_byte1 = byte1, real_byte5 = byte5;
 	boolean ap_enable = FALSE, result = FALSE;
-	struct btc_bt_link_info *bt_link_info = &btc->bt_link_info;
 	u8 ps_type = BTC_PS_WIFI_NATIVE;
 
 	if (byte5 & BIT(2))
@@ -2146,7 +2134,6 @@ halbtc8822b1ant_tdma(struct btc_coexist *btc, boolean force_exec,
 {
 	struct coex_sta_8822b_1ant *coex_sta = &btc->coex_sta_8822b_1ant;
 	struct coex_dm_8822b_1ant *coex_dm = &btc->coex_dm_8822b_1ant;
-	struct btc_bt_link_info *bt_link_info = &btc->bt_link_info;
 	u8 type;
 
 	btc->btc_set_atomic(btc, &coex_dm->setting_tdma, TRUE);
@@ -3319,7 +3306,6 @@ halbtc8822b1ant_action_wifi_native_lps(struct btc_coexist *btc)
 {
 	struct wifi_link_info_8822b_1ant *wifi_link_info_ext =
 					 &btc->wifi_link_info_8822b_1ant;
-	struct btc_bt_link_info *bt_link_info = &btc->bt_link_info;
 
 	if (wifi_link_info_ext->is_all_under_5g)
 		return;
@@ -3482,7 +3468,6 @@ static void
 halbtc8822b1ant_action_wifi_multiport2g(struct btc_coexist *btc)
 {
 	struct coex_sta_8822b_1ant *coex_sta = &btc->coex_sta_8822b_1ant;
-	struct btc_bt_link_info *bt_link_info = &btc->bt_link_info;
 	u32 traffic_dir;
 	u8 ant_pase;
 
@@ -3848,7 +3833,6 @@ static void halbtc8822b1ant_init_hw_config(struct btc_coexist *btc,
 {
 	struct coex_sta_8822b_1ant *coex_sta = &btc->coex_sta_8822b_1ant;
 	struct rfe_type_8822b_1ant *rfe_type = &btc->rfe_type_8822b_1ant;
-	u8 u8tmp = 0, i = 0;
 	u32 u32tmp1 = 0, u32tmp2 = 0, u32tmp3 = 0;
 
 	BTC_SPRINTF(trace_buf, BT_TMP_BUF_SIZE, "[BTCoex], %s()!\n", __func__);
@@ -3951,7 +3935,6 @@ static void halbtc8822b1ant_init_hw_config(struct btc_coexist *btc,
 
 void ex_halbtc8822b1ant_power_on_setting(struct btc_coexist *btc)
 {
-	struct coex_sta_8822b_1ant *coex_sta = &btc->coex_sta_8822b_1ant;
 	struct btc_board_info *board_info = &btc->board_info;
 	u8 u8tmp = 0x0;
 	u16 u16tmp = 0x0;
@@ -5418,8 +5401,6 @@ void ex_halbtc8822b1ant_tx_rate_change_notify(struct btc_coexist *btc,
 
 void ex_halbtc8822b1ant_rf_status_notify(struct btc_coexist *btc, u8 type)
 {
-	struct coex_sta_8822b_1ant *coex_sta = &btc->coex_sta_8822b_1ant;
-
 	BTC_SPRINTF(trace_buf, BT_TMP_BUF_SIZE, "[BTCoex], RF Status notify\n");
 	BTC_TRACE(trace_buf);
 

--- a/hal/btc/halbtc8822b2ant.c
+++ b/hal/btc/halbtc8822b2ant.c
@@ -161,8 +161,6 @@ halbtc8822b2ant_limited_tx(struct btc_coexist *btc, boolean force_exec,
 			   boolean tx_limit_en, boolean ampdu_limit_en)
 {
 	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-	struct wifi_link_info_8822b_2ant *wifi_link_info_ext =
-					 &btc->wifi_link_info_8822b_2ant;
 	boolean wifi_under_b_mode = FALSE;
 
 	/* Force Max Tx retry limit = 8*/
@@ -620,9 +618,6 @@ static void halbtc8822b2ant_monitor_bt_ctr(struct btc_coexist *btc)
 	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
 	u32 reg_hp_txrx, reg_lp_txrx, u32tmp;
 	u32 reg_hp_tx = 0, reg_hp_rx = 0, reg_lp_tx = 0, reg_lp_rx = 0;
-	static u8 num_of_bt_counter_chk, cnt_autoslot_hang;
-
-	struct btc_bt_link_info *bt_link_info = &btc->bt_link_info;
 
 	reg_hp_txrx = 0x770;
 	reg_lp_txrx = 0x774;
@@ -666,7 +661,6 @@ static void halbtc8822b2ant_monitor_wifi_ctr(struct btc_coexist *btc)
 	u32 cnt_cck;
 	static u8 cnt_ccklocking;
 	u8 h2c_parameter[1] = {0};
-	struct btc_bt_link_info *bt_link_info = &btc->bt_link_info;
 
 #if 0
 	/*send h2c to query WL FW dbg info  */
@@ -819,7 +813,6 @@ halbtc8822b2ant_moniter_wifibt_status(struct btc_coexist *btc)
 	u32 num_of_wifi_link = 0, wifi_link_mode = 0;
 	static u32 pre_num_of_wifi_link, pre_wifi_link_mode;
 	boolean miracast_plus_bt = FALSE;
-	u8 lna_lvl = 1;
 
 	btc->btc_get(btc, BTC_GET_BL_WIFI_CONNECTED, &wifi_connected);
 	btc->btc_get(btc, BTC_GET_BL_WIFI_BUSY, &wifi_busy);
@@ -1403,7 +1396,6 @@ static void halbtc8822b2ant_update_bt_link_info(struct btc_coexist *btc)
 static void
 halbtc8822b2ant_update_wifi_ch_info(struct btc_coexist *btc, u8 type)
 {
-	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
 	struct coex_dm_8822b_2ant *coex_dm = &btc->coex_dm_8822b_2ant;
 	struct wifi_link_info_8822b_2ant *wifi_link_info_ext =
 					 &btc->wifi_link_info_8822b_2ant;
@@ -1638,8 +1630,6 @@ halbtc8822b2ant_wait_indirect_reg_ready(struct btc_coexist *btc)
 static u32
 halbtc8822b2ant_read_indirect_reg(struct btc_coexist *btc, u16 reg_addr)
 {
-	u32 delay_count = 0;
-
 	halbtc8822b2ant_wait_indirect_reg_ready(btc);
 
 	/* wait for ready bit before access 0x1700		 */
@@ -1651,7 +1641,7 @@ static void
 halbtc8822b2ant_write_indirect_reg(struct btc_coexist *btc, u16 reg_addr,
 				   u32 bit_mask, u32 reg_value)
 {
-	u32 val, i = 0, bitpos = 0, delay_count = 0;
+	u32 val, i = 0, bitpos = 0;
 
 	if (bit_mask == 0x0)
 		return;
@@ -2077,7 +2067,6 @@ static void halbtc8822b2ant_set_tdma(struct btc_coexist *btc, u8 byte1,
 	u8 h2c_parameter[5] = {0};
 	u8 real_byte1 = byte1, real_byte5 = byte5;
 	boolean ap_enable = FALSE, result = FALSE;
-	struct btc_bt_link_info *bt_link_info = &btc->bt_link_info;
 	u8 ps_type = BTC_PS_WIFI_NATIVE;
 
 	if (byte5 & BIT(2))
@@ -2168,7 +2157,6 @@ halbtc8822b2ant_tdma(struct btc_coexist *btc, boolean force_exec,
 {
 	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
 	struct coex_dm_8822b_2ant *coex_dm = &btc->coex_dm_8822b_2ant;
-	struct btc_bt_link_info *bt_link_info = &btc->bt_link_info;
 	u8 type;
 
 	btc->btc_set_atomic(btc, &coex_dm->setting_tdma, TRUE);
@@ -2943,7 +2931,6 @@ static void halbtc8822b2ant_action_bt_whql_test(struct btc_coexist *btc)
 static void halbtc8822b2ant_action_bt_relink(struct btc_coexist *btc)
 {
 	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-	struct btc_bt_link_info *bt_link_info = &btc->bt_link_info;
 
 	halbtc8822b2ant_set_wl_tx_power(btc, NM_EXCU, 0xd8);
 	halbtc8822b2ant_set_bt_tx_power(btc, NM_EXCU, 0);
@@ -3082,7 +3069,6 @@ static void halbtc8822b2ant_action_bt_inquiry(struct btc_coexist *btc)
 static void halbtc8822b2ant_action_sco(struct btc_coexist *btc)
 {
 	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-	struct coex_dm_8822b_2ant *coex_dm = &btc->coex_dm_8822b_2ant;
 
 	halbtc8822b2ant_set_wl_tx_power(btc, NM_EXCU, 0xd8);
 	halbtc8822b2ant_set_bt_tx_power(btc, NM_EXCU, 0);
@@ -3108,7 +3094,6 @@ static void halbtc8822b2ant_action_sco(struct btc_coexist *btc)
 static void halbtc8822b2ant_action_hid(struct btc_coexist *btc)
 {
 	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-	struct coex_dm_8822b_2ant *coex_dm = &btc->coex_dm_8822b_2ant;
 
 	halbtc8822b2ant_set_wl_tx_power(btc, NM_EXCU, 0xd8);
 	halbtc8822b2ant_set_bt_tx_power(btc, NM_EXCU, 0);
@@ -3132,9 +3117,6 @@ static void halbtc8822b2ant_action_hid(struct btc_coexist *btc)
 
 static void halbtc8822b2ant_action_a2dpsink(struct btc_coexist *btc)
 {
-	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-	struct coex_dm_8822b_2ant *coex_dm = &btc->coex_dm_8822b_2ant;
-
 	halbtc8822b2ant_set_wl_tx_power(btc, NM_EXCU, 0xd8);
 	halbtc8822b2ant_set_bt_tx_power(btc, NM_EXCU, 0);
 	halbtc8822b2ant_set_wl_rx_gain(btc, NM_EXCU, FALSE);
@@ -3150,7 +3132,6 @@ static void halbtc8822b2ant_action_a2dpsink(struct btc_coexist *btc)
 static void halbtc8822b2ant_action_a2dp(struct btc_coexist *btc)
 {
 	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-	struct coex_dm_8822b_2ant *coex_dm = &btc->coex_dm_8822b_2ant;
 	static u8 prewifi_rssi_state2 = BTC_RSSI_STATE_LOW;
 	u8 wifi_rssi_state2;
 	boolean wifi_busy = FALSE;
@@ -3182,8 +3163,6 @@ static void halbtc8822b2ant_action_a2dp(struct btc_coexist *btc)
 
 static void halbtc8822b2ant_action_pan(struct btc_coexist *btc)
 {
-	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-	struct coex_dm_8822b_2ant *coex_dm = &btc->coex_dm_8822b_2ant;
 	boolean wifi_busy = FALSE;
 
 	btc->btc_get(btc, BTC_GET_BL_WIFI_BUSY, &wifi_busy);
@@ -3207,7 +3186,6 @@ static void halbtc8822b2ant_action_pan(struct btc_coexist *btc)
 static void halbtc8822b2ant_action_hid_a2dp(struct btc_coexist *btc)
 {
 	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-	struct coex_dm_8822b_2ant *coex_dm = &btc->coex_dm_8822b_2ant;
 
 	static u8 prewifi_rssi_state2 = BTC_RSSI_STATE_LOW;
 	u8 wifi_rssi_state2;
@@ -3237,8 +3215,6 @@ static void halbtc8822b2ant_action_hid_a2dp(struct btc_coexist *btc)
 
 static void halbtc8822b2ant_action_pan_a2dp(struct btc_coexist *btc)
 {
-	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-	struct coex_dm_8822b_2ant *coex_dm = &btc->coex_dm_8822b_2ant;
 	boolean wifi_busy = FALSE;
 
 	btc->btc_get(btc, BTC_GET_BL_WIFI_BUSY, &wifi_busy);
@@ -3260,8 +3236,6 @@ static void halbtc8822b2ant_action_pan_a2dp(struct btc_coexist *btc)
 
 static void halbtc8822b2ant_action_pan_hid(struct btc_coexist *btc)
 {
-	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-	struct coex_dm_8822b_2ant *coex_dm = &btc->coex_dm_8822b_2ant;
 	boolean wifi_busy = FALSE;
 
 	btc->btc_get(btc, BTC_GET_BL_WIFI_BUSY, &wifi_busy);
@@ -3286,7 +3260,6 @@ static void
 halbtc8822b2ant_action_hid_a2dp_pan(struct btc_coexist *btc)
 {
 	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-	struct coex_dm_8822b_2ant *coex_dm = &btc->coex_dm_8822b_2ant;
 	u8  val;
 	boolean wifi_busy = FALSE;
 	u32 wifi_bw = 1;
@@ -3354,7 +3327,6 @@ halbtc8822b2ant_action_wifi_native_lps(struct btc_coexist *btc)
 {
 	struct wifi_link_info_8822b_2ant *wifi_link_info_ext =
 					 &btc->wifi_link_info_8822b_2ant;
-	struct btc_bt_link_info *bt_link_info = &btc->bt_link_info;
 
 	if (wifi_link_info_ext->is_all_under_5g)
 		return;
@@ -3844,7 +3816,6 @@ static void halbtc8822b2ant_init_hw_config(struct btc_coexist *btc,
 	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
 	struct rfe_type_8822b_2ant *rfe_type = &btc->rfe_type_8822b_2ant;
 	u32 u32tmp1 = 0, u32tmp2 = 0, u32tmp3 = 0;
-	u8 i = 0;
 
 	BTC_SPRINTF(trace_buf, BT_TMP_BUF_SIZE, "[BTCoex], %s()!\n", __func__);
 	BTC_TRACE(trace_buf);
@@ -3941,8 +3912,6 @@ static void halbtc8822b2ant_init_hw_config(struct btc_coexist *btc,
 
 void ex_halbtc8822b2ant_power_on_setting(struct btc_coexist *btc)
 {
-	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-
 	u8 u8tmp = 0x0;
 	u16 u16tmp = 0x0;
 
@@ -5393,8 +5362,6 @@ void ex_halbtc8822b2ant_tx_rate_change_notify(struct btc_coexist *btc,
 
 void ex_halbtc8822b2ant_rf_status_notify(struct btc_coexist *btc, u8 type)
 {
-	struct coex_sta_8822b_2ant *coex_sta = &btc->coex_sta_8822b_2ant;
-
 	BTC_SPRINTF(trace_buf, BT_TMP_BUF_SIZE, "[BTCoex], RF Status notify\n");
 	BTC_TRACE(trace_buf);
 

--- a/hal/hal_btcoex.c
+++ b/hal/hal_btcoex.c
@@ -232,7 +232,7 @@ static void DBG_BT_INFO_INIT(PBTCDBGINFO pinfo, u8 *pbuf, u32 size)
 void DBG_BT_INFO(u8 *dbgmsg)
 {
 	PBTCDBGINFO pinfo;
-	u32 msglen, buflen;
+	u32 msglen;
 	u8 *pbuf;
 
 
@@ -614,7 +614,6 @@ struct btc_wifi_link_info halbtcoutsrc_getwifilinkinfo(PBTC_COEXIST pBtCoexist)
 	PADAPTER adapter = NULL;
 	PADAPTER iface = NULL;
 	PADAPTER sta_iface = NULL, p2p_iface = NULL, ap_iface = NULL;
-	BTC_LINK_MODE btc_link_moe = BTC_LINK_MAX;
 	struct dvobj_priv *dvobj = NULL;
 	struct mlme_ext_priv *mlmeext = NULL;
 	struct btc_wifi_link_info wifi_link_info;
@@ -1009,8 +1008,6 @@ static u8 halbtcoutsrc_GetWifiScanAPNum(PADAPTER padapter)
 
 u32 halbtcoutsrc_GetPhydmVersion(void *pBtcContext)
 {
-	struct btc_coexist *pBtCoexist = (struct btc_coexist *)pBtcContext;
-	PADAPTER		Adapter = pBtCoexist->Adapter;
 
 #ifdef CONFIG_RTL8192E
 	return RELEASE_VERSION_8192E;
@@ -1381,7 +1378,6 @@ u16 halbtcoutsrc_LnaConstrainLvl(void *pBtcContext, u8 *lna_constrain_level)
 
 	if (halbtcoutsrc_IsHwMailboxExist(pBtCoexist) == _TRUE) {
 		_irqL irqL;
-		u8 op_code;
 
 		_enter_critical_mutex(&GLBtcBtMpOperLock, &irqL);
 
@@ -1884,14 +1880,12 @@ void halbtcoutsrc_DisplayBtLinkInfo(PBTC_COEXIST pBtCoexist)
 void halbtcoutsrc_DisplayWifiStatus(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER	padapter = pBtCoexist->Adapter;
-	struct pwrctrl_priv *pwrpriv = adapter_to_pwrctl(padapter);
 	u8			*cliBuf = pBtCoexist->cli_buf;
-	s32			wifiRssi = 0, btHsRssi = 0;
+	s32			wifiRssi = 0;
 	BOOLEAN	bScan = _FALSE, bLink = _FALSE, bRoam = _FALSE, bWifiBusy = _FALSE, bWifiUnderBMode = _FALSE;
 	u32			wifiBw = BTC_WIFI_BW_HT20, wifiTrafficDir = BTC_WIFI_TRAFFIC_TX, wifiFreq = BTC_FREQ_2_4G;
 	u32			wifiLinkStatus = 0x0;
-	BOOLEAN	bBtHsOn = _FALSE, bLowPower = _FALSE;
-	u8			wifiChnl = 0, wifiP2PChnl = 0, nScanAPNum = 0, FwPSState;
+	u8			wifiChnl = 0, wifiP2PChnl = 0, nScanAPNum = 0;
 	u32			iqk_cnt_total = 0, iqk_cnt_ok = 0, iqk_cnt_fail = 0;
 	u16			wifiBcnInterval = 0;
 	PHAL_DATA_TYPE hal = GET_HAL_DATA(padapter);
@@ -2595,7 +2589,6 @@ static void halbtcoutsrc_coex_offload_init(void)
 static COL_H2C_STATUS halbtcoutsrc_send_h2c(PADAPTER Adapter, PCOL_H2C pcol_h2c, u16 h2c_cmd_len)
 {
 	COL_H2C_STATUS		h2c_status = COL_STATUS_C2H_OK;
-	u8				i;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0))
 	reinit_completion(&gl_coex_offload.c2h_event[pcol_h2c->req_num]);		/* set event to un signaled state */
@@ -2654,10 +2647,9 @@ COL_H2C_STATUS halbtcoutsrc_CoexH2cProcess(void *pBtCoexist,
 	PADAPTER			Adapter = ((struct btc_coexist *)pBtCoexist)->Adapter;
 	u8				H2C_Parameter[BTC_TMP_BUF_SHORT] = {0};
 	PCOL_H2C			pcol_h2c = (PCOL_H2C)&H2C_Parameter[0];
-	u16				paraLen = 0;
 	COL_H2C_STATUS		h2c_status = COL_STATUS_C2H_OK, c2h_status = COL_STATUS_C2H_OK;
 	COL_H2C_STATUS		ret_status = COL_STATUS_C2H_OK;
-	u16				i, col_h2c_len = 0;
+	u16				col_h2c_len = 0;
 
 	pcol_h2c->opcode = opcode;
 	pcol_h2c->opcode_ver = opcode_ver;
@@ -5614,7 +5606,6 @@ void hal_btcoex_SetPgAntNum(PADAPTER padapter, u8 antNum)
 
 u8 hal_btcoex_Initialize(PADAPTER padapter)
 {
-	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(padapter);
 	u8 ret;
 
 	_rtw_memset(&GLBtCoexist, 0, sizeof(GLBtCoexist));
@@ -6169,12 +6160,10 @@ hal_btcoex_ParseAntIsolationConfigFile(
 	char			*buffer
 )
 {
-	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(Adapter);
 	u32	i = 0 , j = 0;
 	char	*szLine , *ptmp;
 	int rtStatus = _SUCCESS;
 	char param_value_string[10];
-	u8 param_value;
 	u8 anttype = 4;
 
 	u8 ant_num = 3 , ant_distance = 50 , rfe_type = 1;

--- a/hal/hal_btcoex_wifionly.c
+++ b/hal/hal_btcoex_wifionly.c
@@ -229,7 +229,6 @@ void hal_btcoex_wifionly_initlizevariables(PADAPTER padapter)
 {
 	struct wifi_only_cfg		*pwifionlycfg = &GLBtCoexistWifiOnly;
 	struct wifi_only_haldata	*pwifionly_haldata = &pwifionlycfg->haldata_info;
-	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(padapter);
 
 	_rtw_memset(&GLBtCoexistWifiOnly, 0, sizeof(GLBtCoexistWifiOnly));
 

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -13592,8 +13592,9 @@ exit:
 void rtw_dump_cur_efuse(PADAPTER padapter)
 {
 	int mapsize =0;
+#ifdef CONFIG_RTW_DEBUG
 	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(padapter);
-
+#endif
 	EFUSE_GetEfuseDefinition(padapter, EFUSE_WIFI, TYPE_EFUSE_MAP_LEN , (void *)&mapsize, _FALSE);
 
 	if (mapsize <= 0 || mapsize > EEPROM_MAX_SIZE) {

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -7867,7 +7867,6 @@ static void rtw_hal_construct_PSPoll(_adapter *padapter,
 {
 	struct rtw_ieee80211_hdr	*pwlanhdr;
 	u16					*fctrl;
-	u32					pktlen;
 	struct mlme_ext_priv	*pmlmeext = &(padapter->mlmeextpriv);
 	struct mlme_ext_info	*pmlmeinfo = &(pmlmeext->mlmext_info);
 
@@ -10998,7 +10997,6 @@ static void _rtw_hal_set_fw_rsvd_page(_adapter *adapter, bool finished, u8 *page
 	struct mlme_priv *pmlmepriv = &adapter->mlmepriv;
 	u32	BeaconLength = 0, ProbeRspLength = 0, PSPollLength = 0;
 	u32	NullDataLength = 0, QosNullLength = 0, BTQosNullLength = 0;
-	u32	ProbeReqLength = 0, NullFunctionDataLength = 0;
 	u8	TxDescLen = TXDESC_SIZE, TxDescOffset = TXDESC_OFFSET;
 	u8	TotalPageNum = 0 , CurtPktPageNum = 0 , RsvdPageNum = 0;
 	u8	*ReservedPagePacket;
@@ -11597,9 +11595,7 @@ static void hw_var_set_mlme_sitesurvey(_adapter *adapter, u8 enable)
 #ifndef CONFIG_HAS_HW_VAR_MLME_JOIN
 static void hw_var_set_mlme_join(_adapter *adapter, u8 type)
 {
-	u8 val8;
 	u16 val16;
-	u32 val32;
 	u8 RetryLimit = RL_VAL_STA;
 	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(adapter);
 	struct mlme_priv *pmlmepriv = &adapter->mlmepriv;
@@ -12633,8 +12629,6 @@ u8 SetHwReg(_adapter *adapter, u8 variable, u8 *val)
 void GetHwReg(_adapter *adapter, u8 variable, u8 *val)
 {
 	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(adapter);
-	u64 val64;
-
 
 	switch (variable) {
 	case HW_VAR_MAC_ADDR:
@@ -12804,8 +12798,6 @@ u8 rtw_hal_query_txbfee_rf_num(_adapter *adapter)
 	struct registry_priv		*pregistrypriv = &adapter->registrypriv;
 	struct mlme_ext_priv	*pmlmeext = &adapter->mlmeextpriv;
 	struct mlme_ext_info	*pmlmeinfo = &(pmlmeext->mlmext_info);
-
-	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(adapter);
 
 	if ((pregistrypriv->beamformee_rf_num) && (IS_HARDWARE_TYPE_8814AE(adapter) || IS_HARDWARE_TYPE_8814AU(adapter) || IS_HARDWARE_TYPE_8822BU(adapter) || IS_HARDWARE_TYPE_8821C(adapter)))
 		return pregistrypriv->beamformee_rf_num;
@@ -14002,7 +13994,6 @@ void dm_DynamicUsbTxAgg(_adapter *padapter, u8 from_timer)
 /* bus-agg check for SoftAP mode */
 inline u8 rtw_hal_busagg_qsel_check(_adapter *padapter, u8 pre_qsel, u8 next_qsel)
 {
-	struct mlme_priv *pmlmepriv = &(padapter->mlmepriv);
 	u8 chk_rst = _SUCCESS;
 
 	if (!MLME_IS_AP(padapter) && !MLME_IS_MESH(padapter))

--- a/hal/hal_com_phycfg.c
+++ b/hal/hal_com_phycfg.c
@@ -2938,7 +2938,6 @@ s8 phy_get_txpwr_lmt(
 	u8 lock
 )
 {
-	struct dvobj_priv *dvobj = adapter_to_dvobj(Adapter);
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(Adapter);
 	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(Adapter);
 	struct hal_spec_t *hal_spec = GET_HAL_SPEC(Adapter);
@@ -3045,7 +3044,6 @@ inline s8 phy_get_txpwr_lmt_diff(_adapter *adapter
 	, u8 rfpath, u8 rs, u8 tlrs, u8 ntx_idx, u8 cch, u8 lock
 )
 {
-	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(adapter);
 	struct hal_spec_t *hal_spec = GET_HAL_SPEC(adapter);
 	s8 lmt = phy_get_txpwr_lmt(adapter, regd_name, band, bw, tlrs, ntx_idx, cch, lock);
 
@@ -3599,11 +3597,10 @@ phy_set_tx_power_limit(
 {
 #if CONFIG_TXPWR_LIMIT
 	PADAPTER Adapter = pDM_Odm->adapter;
-	HAL_DATA_TYPE *pHalData = GET_HAL_DATA(Adapter);
 	struct hal_spec_t *hal_spec = GET_HAL_SPEC(Adapter);
 	u8 band = 0, bandwidth = 0, tlrs = 0, channel;
 	u8 ntx_idx;
-	s8 powerLimit = 0, prevPowerLimit, channelIndex;
+	s8 powerLimit = 0, channelIndex;
 	s8 ww_lmt_val = phy_txpwr_ww_lmt_value(Adapter);
 
 	if (0)
@@ -5040,7 +5037,6 @@ PHY_ConfigRFWithTxPwrTrackParaFile(
 )
 {
 	HAL_DATA_TYPE		*pHalData = GET_HAL_DATA(Adapter);
-	struct dm_struct			*pDM_Odm = &pHalData->odmpriv;
 	int	rlen = 0, rtStatus = _FAIL;
 	char	*szLine, *ptmp;
 	u32	i = 0;
@@ -5946,7 +5942,6 @@ s16 phy_get_txpwr_total_mbm(_adapter *adapter, RATE_SECTION rs, u8 rate
 static s16 _phy_get_txpwr_max_mbm(_adapter *adapter, s8 rfpath
 	, enum channel_width bw, u8 cch, u8 opch, u16 bmp_cck_ofdm, u32 bmp_ht, u64 bmp_vht)
 {
-	struct hal_spec_t *hal_spec = GET_HAL_SPEC(adapter);
 	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(adapter);
 	BAND_TYPE band = cch <= 14 ? BAND_ON_2_4G : BAND_ON_5G;
 	u8 tx_num;

--- a/hal/hal_dm.c
+++ b/hal/hal_dm.c
@@ -1627,7 +1627,6 @@ static u8 _rtw_phydm_pwr_tracking_rate_check(_adapter *adapter)
 	u8		if_tx_rate = 0xFF;
 	u8		tx_rate = 0xFF;
 	struct mlme_ext_priv	*pmlmeext = NULL;
-	struct mlme_priv *pmlmepriv = &adapter->mlmepriv;
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	HAL_DATA_TYPE *pHalData = GET_HAL_DATA(adapter);
 

--- a/hal/hal_dm_acs.c
+++ b/hal/hal_dm_acs.c
@@ -22,7 +22,6 @@ static void _rtw_bss_nums_count(_adapter *adapter, u8 *pbss_nums)
 	struct mlme_priv	*pmlmepriv = &(adapter->mlmepriv);
 	_queue *queue = &(pmlmepriv->scanned_queue);
 	struct wlan_network *pnetwork = NULL;
-	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(adapter);
 
 	_list	*plist, *phead;
 	_irqL irqL;
@@ -115,8 +114,6 @@ void rtw_acs_adv_setting(_adapter *adapter, RT_SCAN_TYPE scan_type, u16 scan_tim
 {
 	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(adapter);
 	struct auto_chan_sel *pacs = &hal_data->acs;
-	struct mlme_ext_priv *pmlmeext = &adapter->mlmeextpriv;
-	struct mlme_ext_info *pmlmeinfo = &pmlmeext->mlmext_info;
 
 	pacs->scan_type = scan_type;
 	pacs->scan_time = scan_time;
@@ -274,9 +271,11 @@ void _rtw_phydm_acs_select_best_chan(_adapter *adapter)
 void rtw_acs_info_dump(void *sel, _adapter *adapter)
 {
 	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(adapter);
+#ifdef CONFIG_RTW_ACS_DBG
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
 	u8 max_chan_nums = rfctl->max_chan_nums;
 	u8 ch_idx, ch_num;
+#endif
 
 	_RTW_PRINT_SEL(sel, "========== ACS (VER-%d) ==========\n", RTK_ACS_VERSION);
 	_RTW_PRINT_SEL(sel, "Best 24G Channel:%d\n", hal_data->acs.best_chan_24g);

--- a/hal/hal_halmac.c
+++ b/hal/hal_halmac.c
@@ -3422,11 +3422,8 @@ static int init_mac_flow(struct dvobj_priv *d)
 	struct hal_com_data *hal;
 	struct halmac_adapter *halmac;
 	struct halmac_api *api;
-	enum halmac_drv_rsvd_pg_num rsvd_page_number;
-	union halmac_wlan_addr hwa;
 	enum halmac_trx_mode trx_mode;
 	enum halmac_ret_status status;
-	u8 drv_rsvd_num;
 	u8 nettype;
 	int err, err_ret = -1;
 
@@ -3921,7 +3918,6 @@ int rtw_halmac_dlfw_mem_from_file(struct dvobj_priv *d, u8 *fwpath, enum fw_mem 
 int rtw_halmac_dlfw(struct dvobj_priv *d, u8 *fw, u32 fwsize)
 {
 	PADAPTER adapter;
-	enum halmac_ret_status status;
 	u32 ok;
 	int err, err_ret = -1;
 

--- a/hal/hal_intf.c
+++ b/hal/hal_intf.c
@@ -56,7 +56,9 @@ u8 rtw_hal_read_chip_info(_adapter *padapter)
 {
 	u8 rtn = _SUCCESS;
 	u8 hci_type = rtw_get_intf_type(padapter);
+#ifdef CONFIG_RTW_DEBUG
 	systime start = rtw_get_current_time();
+#endif
 
 	/*  before access eFuse, make sure card enable has been called */
 	if ((hci_type == RTW_SDIO || hci_type == RTW_GSPI)
@@ -704,7 +706,9 @@ s32 rtw_hal_fw_dl(_adapter *padapter, u8 wowlan)
 #ifdef RTW_HALMAC
 s32 rtw_hal_fw_mem_dl(_adapter *padapter, enum fw_mem mem)
 {
+#ifdef CONFIG_RTW_DEBUG
 	systime dlfw_start_time = rtw_get_current_time();
+#endif
 	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
 	struct debug_priv *pdbgpriv = &dvobj->drv_dbg;
 	s32 rst = _FALSE;

--- a/hal/hal_intf.c
+++ b/hal/hal_intf.c
@@ -237,7 +237,6 @@ enum rf_type rtw_chip_rftype_to_hal_rftype(_adapter *adapter, u8 limit)
 
 void dump_hal_runtime_trx_mode(void *sel, _adapter *adapter)
 {
-	struct registry_priv *regpriv = &adapter->registrypriv;
 	PHAL_DATA_TYPE hal_data = GET_HAL_DATA(adapter);
 	int i;
 
@@ -250,7 +249,6 @@ void dump_hal_runtime_trx_mode(void *sel, _adapter *adapter)
 
 void dump_hal_trx_mode(void *sel, _adapter *adapter)
 {
-	struct registry_priv *regpriv = &adapter->registrypriv;
 	PHAL_DATA_TYPE hal_data = GET_HAL_DATA(adapter);
 
 	RTW_PRINT_SEL(sel, "trx_path_bmp:0x%02x(%s), NumTotalRFPath:%u, max_tx_cnt:%u\n"
@@ -315,7 +313,6 @@ if (IS_HARDWARE_TYPE_8814A(adapter)) {
 	enum rf_type type;
 	u8 tx_path_num;
 	u8 rx_path_num;
-	int i;
 
 	ic_cap = rtw_chip_rftype_to_hal_rftype(adapter, hal_spec->rf_reg_path_num);
 	if (!RF_TYPE_VALID(ic_cap)) {
@@ -1192,7 +1189,6 @@ bool rtw_hal_c2h_reg_hdr_parse(_adapter *adapter, u8 *buf, u8 *id, u8 *seq, u8 *
 #ifdef CONFIG_FW_C2H_PKT
 bool rtw_hal_c2h_pkt_hdr_parse(_adapter *adapter, u8 *buf, u16 len, u8 *id, u8 *seq, u8 *plen, u8 **payload)
 {
-	HAL_DATA_TYPE *HalData = GET_HAL_DATA(adapter);
 	bool ret = _FAIL;
 
 	if (!buf || len > 256 || len < 3)

--- a/hal/hal_mp.c
+++ b/hal/hal_mp.c
@@ -1295,7 +1295,7 @@ void mpt_SetRFPath_819X(PADAPTER	pAdapter)
 	R_ANTENNA_SELECT_CCK	*p_cck_txrx;
 	u8		r_rx_antenna_ofdm = 0, r_ant_select_cck_val = 0;
 	u8		chgTx = 0, chgRx = 0;
-	u32		r_ant_sel_cck_val = 0, r_ant_select_ofdm_val = 0, r_ofdm_tx_en_val = 0;
+	u32		r_ant_select_ofdm_val = 0, r_ofdm_tx_en_val = 0;
 
 	ulAntennaTx = pHalData->antenna_tx_path;
 	ulAntennaRx = pHalData->AntennaRxPath;
@@ -1426,7 +1426,6 @@ void mpt_SetRFPath_819X(PADAPTER	pAdapter)
 		case RF_8225:
 		case RF_8256:
 		case RF_6052:
-			/*/r_ant_sel_cck_val = r_ant_select_cck_val;*/
 			phy_set_bb_reg(pAdapter, rFPGA1_TxInfo, 0x7fffffff, r_ant_select_ofdm_val);		/*/OFDM Tx*/
 			phy_set_bb_reg(pAdapter, rFPGA0_TxInfo, 0x0000000f, r_ofdm_tx_en_val);		/*/OFDM Tx*/
 			phy_set_bb_reg(pAdapter, rOFDM0_TRxPathEnable, 0x0000000f, r_rx_antenna_ofdm);	/*/OFDM Rx*/
@@ -1435,7 +1434,7 @@ void mpt_SetRFPath_819X(PADAPTER	pAdapter)
 				phy_set_bb_reg(pAdapter, rOFDM0_TRxPathEnable, 0x000000F0, r_rx_antenna_ofdm);	/*/OFDM Rx*/
 				phy_set_bb_reg(pAdapter, rOFDM1_TRxPathEnable, 0x000000F0, r_rx_antenna_ofdm);	/*/OFDM Rx*/
 			}
-			phy_set_bb_reg(pAdapter, rCCK0_AFESetting, bMaskByte3, r_ant_select_cck_val);/*/r_ant_sel_cck_val); /CCK TxRx*/
+			phy_set_bb_reg(pAdapter, rCCK0_AFESetting, bMaskByte3, r_ant_select_cck_val);/*/CCK TxRx*/
 			break;
 
 		default:
@@ -1667,8 +1666,6 @@ void hal_mpt_GetThermalMeter(PADAPTER pAdapter, u8 rfpath, u8 *value)
 
 void hal_mpt_SetSingleCarrierTx(PADAPTER pAdapter, u8 bStart)
 {
-	HAL_DATA_TYPE *pHalData = GET_HAL_DATA(pAdapter);
-
 	pAdapter->mppriv.mpt_ctx.bSingleCarrier = bStart;
 
 	if (bStart) {/*/ Start Single Carrier.*/
@@ -2076,9 +2073,7 @@ static	void mpt_StopCckContTx(
 	PADAPTER	pAdapter
 )
 {
-	HAL_DATA_TYPE	*pHalData	= GET_HAL_DATA(pAdapter);
 	PMPT_CONTEXT	pMptCtx = &(pAdapter->mppriv.mpt_ctx);
-	u8			u1bReg;
 
 	pMptCtx->bCckContTx = FALSE;
 	pMptCtx->bOfdmContTx = FALSE;
@@ -2118,10 +2113,7 @@ static	void mpt_StopOfdmContTx(
 	PADAPTER	pAdapter
 )
 {
-	HAL_DATA_TYPE	*pHalData	= GET_HAL_DATA(pAdapter);
 	PMPT_CONTEXT	pMptCtx = &(pAdapter->mppriv.mpt_ctx);
-	u8			u1bReg;
-	u32			data;
 
 	pMptCtx->bCckContTx = FALSE;
 	pMptCtx->bOfdmContTx = FALSE;
@@ -2153,7 +2145,6 @@ static	void mpt_StartCckContTx(
 	PADAPTER		pAdapter
 )
 {
-	HAL_DATA_TYPE	*pHalData	= GET_HAL_DATA(pAdapter);
 	PMPT_CONTEXT	pMptCtx = &(pAdapter->mppriv.mpt_ctx);
 	u32			cckrate;
 
@@ -2207,7 +2198,6 @@ static	void mpt_StartOfdmContTx(
 	PADAPTER		pAdapter
 )
 {
-	HAL_DATA_TYPE	*pHalData	= GET_HAL_DATA(pAdapter);
 	PMPT_CONTEXT	pMptCtx = &(pAdapter->mppriv.mpt_ctx);
 
 	/* 1. if OFDM block on?*/

--- a/hal/phydm/halrf/halrf.c
+++ b/hal/phydm/halrf/halrf.c
@@ -494,8 +494,6 @@ void phydm_get_iqk_cfir(void *dm_void, u8 idx, u8 path, boolean debug)
 void halrf_iqk_dbg_cfir_backup(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct dm_iqk_info *iqk_info = &dm->IQK_info;
-	u8 path, idx, i;
 
 	switch (dm->support_ic_type) {
 #if (RTL8822B_SUPPORT == 1)
@@ -517,11 +515,6 @@ void halrf_iqk_dbg_cfir_backup(void *dm_void)
 void halrf_iqk_dbg_cfir_backup_update(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct dm_iqk_info *iqk = &dm->IQK_info;
-	u8 i, path, idx;
-	u32 bmask13_12 = BIT(13) | BIT(12);
-	u32 bmask20_16 = BIT(20) | BIT(19) | BIT(18) | BIT(17) | BIT(16);
-	u32 data;
 
 	switch (dm->support_ic_type) {
 #if (RTL8822B_SUPPORT == 1)
@@ -542,11 +535,6 @@ void halrf_iqk_dbg_cfir_backup_update(void *dm_void)
 void halrf_iqk_dbg_cfir_reload(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct dm_iqk_info *iqk = &dm->IQK_info;
-	u8 i, path, idx;
-	u32 bmask13_12 = BIT(13) | BIT(12);
-	u32 bmask20_16 = BIT(20) | BIT(19) | BIT(18) | BIT(17) | BIT(16);
-	u32 data;
 
 	switch (dm->support_ic_type) {
 #if (RTL8822B_SUPPORT == 1)
@@ -568,7 +556,6 @@ void halrf_iqk_dbg_cfir_write(void *dm_void, u8 type, u32 path, u32 idx,
 			      u32 i, u32 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct dm_iqk_info *iqk_info = &dm->IQK_info;
 
 	switch (dm->support_ic_type) {
 #if (RTL8822B_SUPPORT == 1)
@@ -589,8 +576,6 @@ void halrf_iqk_dbg_cfir_write(void *dm_void, u8 type, u32 path, u32 idx,
 void halrf_iqk_dbg_cfir_backup_show(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct dm_iqk_info *iqk_info = &dm->IQK_info;
-	u8 path, idx, i;
 
 	switch (dm->support_ic_type) {
 #if (RTL8822B_SUPPORT == 1)
@@ -1381,10 +1366,6 @@ halrf_iqk_init(
 void halrf_reload_iqk(void *dm_void, boolean reset)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct dm_iqk_info *iqk_info = &dm->IQK_info;
-	u8 i, ch;
-	u32 tmp;
-	u32 bit_mask_20_16 = BIT(20) | BIT(19) | BIT(18) | BIT(17) | BIT(16);
 
 	switch (dm->support_ic_type) {
 #if (RTL8822C_SUPPORT == 1)
@@ -1499,8 +1480,6 @@ void halrf_dack_dbg(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct _hal_rf_ *rf = &dm->rf_table;
-
-	u64 start_time;
 
 	if (!(rf->rf_supportability & HAL_RF_DACK))
 		return;
@@ -1695,7 +1674,6 @@ void halrf_iqk_trigger(void *dm_void, boolean is_recovery)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
-	struct dm_dpk_info *dpk_info = &dm->dpk_info;
 	struct _hal_rf_ *rf = &dm->rf_table;
 	u64 start_time;
 
@@ -2102,7 +2080,6 @@ void halrf_dpk_trigger(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct _hal_rf_ *rf = &dm->rf_table;
-	struct dm_dpk_info *dpk_info = &dm->dpk_info;
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
 
 	u64 start_time;
@@ -2216,10 +2193,7 @@ void halrf_dpk_trigger(void *dm_void)
 void halrf_set_dpkbychannel(void *dm_void, boolean dpk_by_ch)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct _hal_rf_ *rf = &dm->rf_table;
 	struct dm_dpk_info *dpk_info = &dm->dpk_info;
-	struct dm_iqk_info *iqk_info = &dm->IQK_info;
-
 
 	switch (dm->support_ic_type) {
 #if (RTL8814B_SUPPORT == 1)
@@ -2248,10 +2222,6 @@ void halrf_set_dpkbychannel(void *dm_void, boolean dpk_by_ch)
 void halrf_set_dpkenable(void *dm_void, boolean is_dpk_enable)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct _hal_rf_ *rf = &dm->rf_table;
-	struct dm_dpk_info *dpk_info = &dm->dpk_info;
-	struct dm_iqk_info *iqk_info = &dm->IQK_info;
-
 
 	switch (dm->support_ic_type) {
 #if (RTL8814B_SUPPORT == 1)
@@ -2284,9 +2254,6 @@ void halrf_set_dpkenable(void *dm_void, boolean is_dpk_enable)
 boolean halrf_get_dpkbychannel(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct _hal_rf_ *rf = &dm->rf_table;
-	struct dm_dpk_info *dpk_info = &dm->dpk_info;
-	struct dm_iqk_info *iqk_info = &dm->IQK_info;
 	boolean is_dpk_by_channel = true;
 
 	switch (dm->support_ic_type) {
@@ -2315,9 +2282,6 @@ boolean halrf_get_dpkbychannel(void *dm_void)
 boolean halrf_get_dpkenable(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct _hal_rf_ *rf = &dm->rf_table;
-	struct dm_dpk_info *dpk_info = &dm->dpk_info;
-	struct dm_iqk_info *iqk_info = &dm->IQK_info;
 	boolean is_dpk_enable = true;
 
 
@@ -2443,8 +2407,6 @@ u8 halrf_dpk_result_check(void *dm_void)
 void halrf_dpk_sram_read(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-
-	u8 path, group;
 
 	switch (dm->support_ic_type) {
 #if (RTL8822C_SUPPORT == 1)
@@ -2735,7 +2697,6 @@ void halrf_dpk_info_rsvd_page(void *dm_void, u8 *buf, u32 *buf_size)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct _hal_rf_ *rf = &dm->rf_table;
-	struct dm_dpk_info *dpk_info = &dm->dpk_info;
 
 	if (!(rf->rf_supportability & HAL_RF_DPK) || rf->is_dpk_in_progress)
 		return;
@@ -3210,7 +3171,6 @@ void halrf_bprf(void *dm_void, u32 *bp_reg, u32 bp[][4], u32 num, u8 ss)
 
 void halrf_swap(void *dm_void, u32 *v1, u32 *v2)
 {
-	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 temp;
 
 	temp = *v1;
@@ -3221,7 +3181,6 @@ void halrf_swap(void *dm_void, u32 *v1, u32 *v2)
 void halrf_bubble(void *dm_void, u32 *v1, u32 *v2)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	u32 temp;
 
 	if (*v1 >= 0x200 && *v2 >= 0x200) {
 		if (*v1 > *v2)
@@ -3237,7 +3196,6 @@ void halrf_bubble(void *dm_void, u32 *v1, u32 *v2)
 void halrf_b_sort(void *dm_void, u32 *iv, u32 *qv)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	u32 temp;
 	u32 i, j;
 
 	RF_DBG(dm, DBG_RF_DACK, "[DACK]bubble!!!!!!!!!!!!");
@@ -3252,8 +3210,6 @@ void halrf_b_sort(void *dm_void, u32 *iv, u32 *qv)
 void halrf_minmax_compare(void *dm_void, u32 value, u32 *min,
 			  u32 *max)
 {
-	struct dm_struct *dm = (struct dm_struct *)dm_void;
-
 	if (value >= 0x200) {
 		if (*min >= 0x200) {
 			if (*min > value)
@@ -3282,8 +3238,6 @@ void halrf_minmax_compare(void *dm_void, u32 value, u32 *min,
 
 u32 halrf_delta(void *dm_void, u32 v1, u32 v2)
 {
-	struct dm_struct *dm = (struct dm_struct *)dm_void;
-
 	if (v1 >= 0x200 && v2 >= 0x200) {
 		if (v1 > v2)
 			return v1 - v2;
@@ -3320,11 +3274,11 @@ boolean halrf_compare(void *dm_void, u32 value)
 void halrf_mode(void *dm_void, u32 *i_value, u32 *q_value)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	u32 iv[SN], qv[SN], im[SN], qm[SN], temp, temp1, temp2;
+	u32 iv[SN], qv[SN], im[SN], qm[SN], temp;
 	u32 p, m, t;
 	u32 i_max = 0, q_max = 0, i_min = 0x0, q_min = 0x0, c = 0x0;
 	u32 i_delta, q_delta;
-	u8 i, j, ii = 0, qi = 0;
+	u8 i;
 	boolean fail = false;
 
 	ODM_delay_ms(10);

--- a/hal/phydm/halrf/halrf.c
+++ b/hal/phydm/halrf/halrf.c
@@ -196,7 +196,9 @@ void halrf_iqk_xym_read(void *dm_void, u8 path, u8 xym_type)
 void halrf_iqk_xym_show(struct dm_struct *dm, u8 xym_type)
 {
 	u8 num, path, path_num, i;
+#ifdef CONFIG_RTW_DEBUG
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
+#endif
 
 	if (dm->rf_type == RF_1T1R)
 		path_num = 0x1;
@@ -381,8 +383,10 @@ void halrf_iqk_dbg(void *dm_void)
 	u32 tmp;
 	/*two channel, PATH, TX/RX, 0:pass 1 :fail*/
 	boolean iqk_result[2][NUM][2];
+#ifdef CONFIG_RTW_DEBUG
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
 	struct _hal_rf_ *rf = &dm->rf_table;
+#endif
 
 	/* IQK INFO */
 	RF_DBG(dm, DBG_RF_IQK, "%-20s\n", "====== IQK Info ======");

--- a/hal/phydm/halrf/halrf_kfree.c
+++ b/hal/phydm/halrf/halrf_kfree.c
@@ -194,8 +194,10 @@ void phydm_set_kfree_to_rf_8821c(void *dm_void, u8 e_rf_path, boolean wlg_btg,
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u8 wlg, btg;
 	u32 gain_bmask = (BIT(18) | BIT(17) | BIT(16) | BIT(15) | BIT(14));
+#ifdef CONFIG_RTW_DEBUG
 	u32 s_gain_bmask = (BIT(19) | BIT(18) | BIT(17) |
 			    BIT(16) | BIT(15) | BIT(14));
+#endif
 
 	odm_set_rf_reg(dm, e_rf_path, RF_0xde, BIT(0), 1);
 	odm_set_rf_reg(dm, e_rf_path, RF_0xde, BIT(5), 1);
@@ -227,8 +229,10 @@ void phydm_clear_kfree_to_rf_8821c(void *dm_void, u8 e_rf_path, u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 gain_bmask = (BIT(18) | BIT(17) | BIT(16) | BIT(15) | BIT(14));
+#ifdef CONFIG_RTW_DEBUG
 	u32 s_gain_bmask = (BIT(19) | BIT(18) | BIT(17) |
 			    BIT(16) | BIT(15) | BIT(14));
+#endif
 
 	odm_set_rf_reg(dm, e_rf_path, RF_0xde, BIT(0), 1);
 	odm_set_rf_reg(dm, e_rf_path, RF_0xde, BIT(5), 1);

--- a/hal/phydm/halrf/halrf_kfree.c
+++ b/hal/phydm/halrf/halrf_kfree.c
@@ -959,7 +959,7 @@ void phydm_set_kfree_to_rf_8198f(void *dm_void, u8 e_rf_path, u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
-	u32 band, i;
+	u32 i;
 	s8 pwr_offset[3];
 
 	RF_DBG(dm, DBG_RF_MP,
@@ -1798,8 +1798,6 @@ void phydm_set_power_trim_rf_8195b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
-	u32 band, i;
-	s8 pwr_offset[3];
 
 	RF_DBG(dm, DBG_RF_MP,
 		   "[kfree] %s:Set kfree to rf 0x33\n", __func__);
@@ -2232,7 +2230,6 @@ void phydm_get_set_lna_offset_8197g(void *dm_void)
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
 
 	u8 pg_lna[2] = {0}, i, pg_lna_tmp = 0;
-	u32 rf_reg;
 
 	odm_efuse_one_byte_read(dm, PPG_LNA_2GA_97G, &pg_lna_tmp, false);
 

--- a/hal/phydm/halrf/halrf_psd.c
+++ b/hal/phydm/halrf/halrf_psd.c
@@ -265,8 +265,6 @@ u32 halrf_get_iqk_psd_data(
 	struct dm_struct *dm,
 	u32 point)
 {
-	struct _hal_rf_ *rf = &(dm->rf_table);
-	struct _halrf_psd_data *psd = &(rf->halrf_psd_data);
 	u32 psd_val, psd_val1, psd_val2, psd_point, i, delay_time = 0;
 
 #if (DEV_BUS_TYPE == RT_USB_INTERFACE) || (DEV_BUS_TYPE == RT_SDIO_INTERFACE)
@@ -348,7 +346,7 @@ void halrf_iqk_psd(
 	struct _halrf_psd_data *psd = &(rf->halrf_psd_data);
 
 	u32 i = 0, j = 0, k = 0;
-	u32 psd_reg, avg_org, point_temp, average_tmp = 32, mode, reg_tmp = 5;
+	u32 point_temp, average_tmp = 32, mode, reg_tmp = 5;
 	u64 data_tatal = 0, data_temp[64] = {0};
 	s32 s_point_tmp;
 

--- a/hal/phydm/halrf/rtl8822b/halhwimg8822b_rf.c
+++ b/hal/phydm/halrf/rtl8822b/halhwimg8822b_rf.c
@@ -50,8 +50,11 @@ check_positive(struct dm_struct *dm,
 	       const u32	condition4
 )
 {
-	u32	cond1 = condition1, cond2 = condition2,
-		cond3 = condition3, cond4 = condition4;
+	u32	cond1 = condition1;
+#ifdef CONFIG_RTW_DEBUG
+	u32	cond2 = condition2, cond3 = condition3,
+		cond4 = condition4;
+#endif
 
 	u8	cut_version_for_para =
 		(dm->cut_version ==  ODM_CUT_A) ? 15 : dm->cut_version;
@@ -66,6 +69,7 @@ check_positive(struct dm_struct *dm,
 			(dm->support_interface & 0x0F) << 8  |
 			dm->rfe_type;
 
+#ifdef CONFIG_RTW_DEBUG
 	u32	driver2 = (dm->type_glna & 0xFF) <<  0 |
 			(dm->type_gpa & 0xFF)  <<  8 |
 			(dm->type_alna & 0xFF) << 16 |
@@ -77,6 +81,7 @@ check_positive(struct dm_struct *dm,
 			(dm->type_gpa & 0xFF00) |
 			(dm->type_alna & 0xFF00) << 8 |
 			(dm->type_apa & 0xFF00)  << 16;
+#endif
 
 	PHYDM_DBG(dm, ODM_COMP_INIT,
 		  "===> %s (cond1, cond2, cond3, cond4) = (0x%X 0x%X 0x%X 0x%X)\n",

--- a/hal/phydm/halrf/rtl8822b/halrf_8822b.c
+++ b/hal/phydm/halrf/rtl8822b/halrf_8822b.c
@@ -285,7 +285,9 @@ void odm_tx_pwr_track_set_pwr8822b(void *dm_void, enum pwrtrack_method method,
 #if (DM_ODM_SUPPORT_TYPE & ODM_WIN)
 	struct _ADAPTER *adapter = dm->adapter;
 #endif
+#ifdef CONFIG_RTW_DEBUG
 	struct dm_rf_calibration_struct *cali_info = &dm->rf_calibrate_info;
+#endif
 	struct _hal_rf_ *rf = &dm->rf_table;
 	u8 tx_pwr_idx_offset = 0;
 	u8 tx_pwr_idx = 0;

--- a/hal/phydm/halrf/rtl8822b/halrf_iqk_8822b.c
+++ b/hal/phydm/halrf/rtl8822b/halrf_iqk_8822b.c
@@ -1598,7 +1598,6 @@ u32 _iqk_rximr_selfcheck_8822b(void *dm_void, u32 tone_index, u8 path,
 boolean _iqk_get_rxk1_8822b(struct dm_struct *dm, u8 path, u8 imr_limit,
 			    u8 side, u32 temp[][15])
 {
-	struct dm_iqk_info *iqk = &dm->IQK_info;
 	boolean kfail = true;
 	u8 i, count = 0;
 	u32 tone_index;
@@ -1655,7 +1654,6 @@ boolean _iqk_get_rxk1_8822b(struct dm_struct *dm, u8 path, u8 imr_limit,
 void _iqk_get_rxk2_8822b(struct dm_struct *dm, u8 path, u8 imr_limit, u8 side,
 			 u32 temp[][15])
 {
-	struct dm_iqk_info *iqk = &dm->IQK_info;
 	u8 i;
 	u32 tone_index, imr_result;
 	char *freq[15] = {
@@ -1690,8 +1688,7 @@ void _iqk_rximr_test_8822b(struct dm_struct *dm, u8 path, u8 imr_limit)
 {
 	struct dm_iqk_info *iqk = &dm->IQK_info;
 	boolean kfail;
-	u8 i, step, count, side;
-	u32 imr_result = 0, tone_index;
+	u8 step, count, side;
 	u32 temp = 0, temp1b38[2][15];
 	u32 cmd = 0xf8000008;
 

--- a/hal/phydm/halrf/rtl8822b/halrf_iqk_8822b.c
+++ b/hal/phydm/halrf/rtl8822b/halrf_iqk_8822b.c
@@ -975,7 +975,9 @@ _iqk_one_shot_8822b(void *dm_void, u8 path, u8 idx)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_iqk_info *iqk = &dm->IQK_info;
+#ifdef CONFIG_RTW_DEBUG
 	u8 delay_count = 0;
+#endif
 	boolean fail = true;
 	u32 IQK_CMD = 0x0, tmp;
 	u16 iqk_apply[2] = {0xc94, 0xe94};
@@ -1656,10 +1658,12 @@ void _iqk_get_rxk2_8822b(struct dm_struct *dm, u8 path, u8 imr_limit, u8 side,
 {
 	u8 i;
 	u32 tone_index, imr_result;
+#ifdef CONFIG_RTW_DEBUG
 	char *freq[15] = {
 		"1.25MHz", "3.75MHz", "6.25MHz", "8.75MHz", "11.25MHz",
 		"13.75MHz", "16.25MHz", "18.75MHz", "21.25MHz", "23.75MHz",
 		"26.25MHz", "28.75MHz", "31.25MHz", "33.75MHz", "36.25MHz"};
+#endif
 
 	for (i = 0x0; i < imr_limit; i++) {
 		if (side == 0)
@@ -1989,7 +1993,9 @@ void phy_get_iqk_cfir_8822b(void *dm_void, u8 idx, u8 path, boolean debug)
 void phy_iqk_dbg_cfir_backup_8822b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
+#ifdef CONFIG_RTW_DEBUG
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
+#endif
 	u8 path, idx, i;
 
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]%-20s\n", "backup TX/RX CFIR");
@@ -2129,7 +2135,9 @@ void phy_iqk_dbg_cfir_write_8822b(void *dm_void, u8 type, u32 path, u32 idx,
 void phy_iqk_dbg_cfir_backup_show_8822b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
+#ifdef CONFIG_RTW_DEBUG
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
+#endif
 	u8 path, idx, i;
 
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]%-20s\n", "backup TX/RX CFIR");

--- a/hal/phydm/phydm.c
+++ b/hal/phydm/phydm.c
@@ -1867,8 +1867,6 @@ u8 phydm_pause_func(void *dm_void, enum phydm_func_idx pause_func,
 	u32 ori_val[5] = {0};
 	u64 pause_func_bitmap = (u64)BIT(pause_func);
 	u8 i = 0;
-	u8 en_2rcca = 0;
-	u8 en_bw40m = 0;
 	u8 pause_result = PAUSE_FAIL;
 
 	PHYDM_DBG(dm, ODM_COMP_API, "\n");

--- a/hal/phydm/phydm_adaptivity.c
+++ b/hal/phydm/phydm_adaptivity.c
@@ -578,7 +578,9 @@ void phydm_set_edcca_threshold_api(void *dm_void)
 {
 #ifdef PHYDM_SUPPORT_ADAPTIVITY
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
+#ifdef CONFIG_RTW_DEBUG
 	struct phydm_adaptivity_struct *adapt = &dm->adaptivity;
+#endif
 
 	if (*dm->edcca_mode != PHYDM_EDCCA_ADAPT_MODE)
 		return;
@@ -768,8 +770,10 @@ void phydm_adaptivity(void *dm_void)
 {
 #ifdef PHYDM_SUPPORT_ADAPTIVITY
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
+#ifdef CONFIG_RTW_DEBUG
 	struct phydm_adaptivity_struct *adapt = &dm->adaptivity;
 	struct phydm_dig_struct *dig_t = &dm->dm_dig_table;
+#endif
 
 	if (phydm_edcca_abort(dm))
 		return;

--- a/hal/phydm/phydm_adaptivity.c
+++ b/hal/phydm/phydm_adaptivity.c
@@ -452,7 +452,6 @@ void phydm_set_edcca_val(void *dm_void, u32 *val_buf, u8 val_len)
 boolean phydm_edcca_abort(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct phydm_adaptivity_struct *adapt = &dm->adaptivity;
 #if (DM_ODM_SUPPORT_TYPE == ODM_WIN)
 	void *adapter = dm->adapter;
 	u32 is_fw_in_psmode = false;

--- a/hal/phydm/phydm_adc_sampling.c
+++ b/hal/phydm/phydm_adc_sampling.c
@@ -1032,7 +1032,6 @@ void phydm_la_set_bb(void *dm_void)
 	u8	smp_rate = smp->la_smp_rate;
 	u8	dma_type = smp->la_dma_type;
 	u32	dbg_port_hdr_sel = 0;
-	char	*trig_mode_word = NULL;
 
 	pr_debug("3. [BB Setting] mode=(%d), Edge=(%s), smp_rate=(%dM), Dma_type=(%d)\n",
 		 trig_mode,
@@ -1561,7 +1560,6 @@ void phydm_la_init(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct rt_adcsmp *smp = &dm->adcsmp;
-	struct rt_adcsmp_string *buf = &smp->adc_smp_buf;
 
 	smp->adc_smp_state = ADCSMP_STATE_IDLE;
 	smp->is_la_print = true;

--- a/hal/phydm/phydm_api.c
+++ b/hal/phydm/phydm_api.c
@@ -108,7 +108,6 @@ void phydm_ant_weight_dbg(void *dm_void, char input[][16], u32 *_used,
 void phydm_trx_antenna_setting_init(void *dm_void, u8 num_rf_path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	u8 rx_ant = 0, tx_ant = 0;
 	u8 path_bitmap = 1;
 
 	path_bitmap = (u8)phydm_gen_bitmask(num_rf_path);

--- a/hal/phydm/phydm_auto_dbg.c
+++ b/hal/phydm/phydm_auto_dbg.c
@@ -682,8 +682,6 @@ void phydm_auto_dbg_console(
 
 void phydm_auto_dbg_engine(void *dm_void)
 {
-	u32 value32 = 0;
-
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_auto_dbg_struct *atd_t = &dm->auto_dbg_table;
 

--- a/hal/phydm/phydm_ccx.c
+++ b/hal/phydm/phydm_ccx.c
@@ -1990,7 +1990,9 @@ void phydm_env_mntr_watchdog(void *dm_void)
 {
 #if (defined(NHM_SUPPORT) && defined(CLM_SUPPORT))
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
+#ifdef CONFIG_RTW_DEBUG
 	struct ccx_info *ccx = &dm->dm_ccx_info;
+#endif
 	boolean nhm_chk_ok = false;
 	boolean clm_chk_ok = false;
 

--- a/hal/phydm/phydm_debug.c
+++ b/hal/phydm/phydm_debug.c
@@ -2366,7 +2366,9 @@ void phydm_get_phy_statistic(void *dm_void)
 void phydm_basic_dbg_msg_linked(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
+#ifdef CONFIG_RTW_DEBUG
 	struct phydm_cfo_track_struct *cfo_t = &dm->dm_cfo_track;
+#endif
 	struct odm_phy_dbg_info *dbg_t = &dm->phy_dbg_info;
 	u16 macid, client_cnt = 0;
 	u8 rate = 0;
@@ -2624,7 +2626,9 @@ void phydm_dm_summary(void *dm_void, u8 macid)
 void phydm_basic_dbg_message(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
+#ifdef CONFIG_RTW_DEBUG
 	struct phydm_fa_struct *fa_t = &dm->false_alm_cnt;
+#endif
 	#ifdef NHM_SUPPORT
 	struct ccx_info *ccx = &dm->dm_ccx_info;
 	u8 nhm_valid = 0;
@@ -3962,7 +3966,9 @@ void phydm_dump_rf_reg(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 
 void phydm_dump_mac_reg(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 {
+#ifdef CONFIG_RTW_DEBUG
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
+#endif
 	u32 addr = 0;
 	u32 used = *_used;
 	u32 out_len = *_out_len;
@@ -5581,6 +5587,7 @@ void phydm_fw_trace_handler_code(void *dm_void, u8 *buffer, u8 cmd_len)
 {
 #ifdef CONFIG_PHYDM_DEBUG_FUNCTION
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
+#ifdef CONFIG_RTW_DEBUG
 	u8 function = buffer[0];
 	u8 dbg_num = buffer[1];
 	u16 content_0 = (((u16)buffer[3]) << 8) | ((u16)buffer[2]);
@@ -5588,6 +5595,7 @@ void phydm_fw_trace_handler_code(void *dm_void, u8 *buffer, u8 cmd_len)
 	u16 content_2 = (((u16)buffer[7]) << 8) | ((u16)buffer[6]);
 	u16 content_3 = (((u16)buffer[9]) << 8) | ((u16)buffer[8]);
 	u16 content_4 = (((u16)buffer[11]) << 8) | ((u16)buffer[10]);
+#endif
 
 	if (cmd_len > 12)
 		PHYDM_DBG(dm, DBG_FW_TRACE,

--- a/hal/phydm/phydm_debug.c
+++ b/hal/phydm/phydm_debug.c
@@ -421,9 +421,9 @@ void phydm_bb_hw_dbg_info_ac(void *dm_void, u32 *_used, char *output,
 	u32 used = *_used;
 	u32 out_len = *_out_len;
 	char *tmp_string = NULL;
-	u8 rx_ht_bw, rx_vht_bw, rxsc, rx_ht, bw_idx = 0;
+	u8 rxsc, rx_ht, bw_idx = 0;
 	static u8 v_rx_bw;
-	u32 value32, value32_1, value32_2, value32_3;
+	u32 value32;
 	struct phydm_cfo_rpt cfo;
 	u8 i = 0;
 	static u8 tail, parity, rsv, vrsv, smooth, htsound, agg;
@@ -431,7 +431,7 @@ void phydm_bb_hw_dbg_info_ac(void *dm_void, u32 *_used, char *output,
 	static u8 vtxops, vrsv2, vbrsv, bf, vbcrc;
 	static u16 h_length, htcrc8, length;
 	static u16 vpaid;
-	static u16 v_length, vhtcrc8, v_mcss, v_tail, vb_tail;
+	static u16 vhtcrc8, v_mcss, v_tail;
 	static u8 hmcss, hrx_bw;
 	u8 pwdb;
 	s8 rxevm_0, rxevm_1, rxevm_2;
@@ -1922,8 +1922,6 @@ u16 phydm_rx_avg_phy_rate(void *dm_void)
 void phydm_print_hist_2_buf(void *dm_void, u16 *val, u16 len, char *buf,
 			    u16 buf_size)
 {
-	struct dm_struct *dm = (struct dm_struct *)dm_void;
-
 	if (len == PHY_HIST_SIZE) {
 		PHYDM_SNPRINTF(buf, buf_size,
 			       "[%.2d, %.2d, %.2d, %.2d, %.2d, %.2d, %.2d, %.2d, %.2d, %.2d, %.2d, %.2d]",
@@ -2032,7 +2030,6 @@ void phydm_show_phy_hitogram(void *dm_void)
 	char buf[PHYDM_SNPRINT_SIZE] = {0};
 	u16 buf_size = PHYDM_SNPRINT_SIZE;
 	u16 th_size = PHY_HIST_SIZE - 1;
-	u8 i = 0;
 
 	PHYDM_DBG(dm, DBG_CMN, "[PHY Histogram] ==============>\n");
 /*@===[Threshold]=============================================================*/
@@ -3996,7 +3993,6 @@ void phydm_dump_reg(void *dm_void, char input[][16], u32 *_used, char *output,
 	u32 var1[10] = {0};
 	u32 used = *_used;
 	u32 out_len = *_out_len;
-	u32 addr = 0;
 
 	if (input[1])
 		PHYDM_SSCANF(input[1], DCMD_DECIMAL, &var1[0]);
@@ -4632,7 +4628,6 @@ void phydm_mp_dbg(void *dm_void, char input[][16], u32 *_used, char *output,
 	char buf[PHYDM_SNPRINT_SIZE] = {0};
 	u32 used = *_used;
 	u32 out_len = *_out_len;
-	u32 var1[10] = {0};
 	u16 buf_size = PHYDM_SNPRINT_SIZE;
 	u16 th_size = PHY_HIST_SIZE - 1;
 	u8 i = 0;

--- a/hal/phydm/phydm_dfs.c
+++ b/hal/phydm/phydm_dfs.c
@@ -844,6 +844,9 @@ phydm_radar_detect_dm_check(
 	u32 regf70_value = 0, regf74_value = 0;
 	u32 rega40_value = 0, rega44_value = 0, rega48_value = 0;
 	u32 rega4c_value = 0, rega50_value = 0, rega54_value = 0;
+#ifdef CONFIG_RTW_DEBUG
+	u32 regdf4_value = 0;
+#endif
 	#if (RTL8721D_SUPPORT)
 	u32 reg908_value = 0, regdf4_value = 0;
 	u32 regf54_value = 0, regf58_value = 0, regf5c_value = 0;

--- a/hal/phydm/phydm_dfs.c
+++ b/hal/phydm/phydm_dfs.c
@@ -169,7 +169,7 @@ void phydm_radar_detect_enable(void *dm_void)
 	u8 region_domain = dm->dfs_region_domain;
 	u8 c_channel = *dm->channel;
 	u8 band_width = *dm->band_width;
-	u8 enable = 0, i;
+	u8 enable = 0;
 	u8 short_pw_upperbound = 0;
 
 	PHYDM_DBG(dm, DBG_DFS, "test, region_domain = %d\n", region_domain);
@@ -829,7 +829,7 @@ phydm_radar_detect_dm_check(
 	struct _DFS_STATISTICS *dfs = &dm->dfs;
 	u8 region_domain = dm->dfs_region_domain, index = 0;
 
-	u16 i = 0, j = 0, k = 0, fa_count_cur = 0, fa_count_inc = 0;
+	u16 i = 0, k = 0, fa_count_cur = 0, fa_count_inc = 0;
 	u16 total_fa_in_hist = 0, pre_post_now_acc_fa_in_hist = 0;
 	u16 max_fa_in_hist = 0, vht_crc_ok_cnt_cur = 0;
 	u16 vht_crc_ok_cnt_inc = 0, ht_crc_ok_cnt_cur = 0;
@@ -841,7 +841,7 @@ phydm_radar_detect_dm_check(
 	u32 regf98_value = 0, reg918_value = 0, reg91c_value = 0;
 	u32 reg920_value = 0, reg924_value = 0, radar_rpt_reg_value = 0;
 	u32 regf54_value = 0, regf58_value = 0, regf5c_value = 0;
-	u32 regdf4_value = 0, regf70_value = 0, regf74_value = 0;
+	u32 regf70_value = 0, regf74_value = 0;
 	u32 rega40_value = 0, rega44_value = 0, rega48_value = 0;
 	u32 rega4c_value = 0, rega50_value = 0, rega54_value = 0;
 	#if (RTL8721D_SUPPORT)
@@ -849,7 +849,7 @@ phydm_radar_detect_dm_check(
 	u32 regf54_value = 0, regf58_value = 0, regf5c_value = 0;
 	u32 regf70_value = 0, regf74_value = 0;
 	#endif
-	boolean tri_short_pulse = 0, tri_long_pulse = 0, radar_type = 0;
+	boolean tri_short_pulse = 0, tri_long_pulse = 0;
 	boolean fault_flag_det = 0, fault_flag_psd = 0, fa_flag = 0;
 	boolean radar_detected = 0;
 	u8 st_l2h_new = 0, fa_mask_th = 0, sum = 0;
@@ -1312,8 +1312,7 @@ void phydm_dfs_histogram_radar_distinguish(
 	u16 j = 0;
 	u32 dfs_hist1_peak_index = 0, dfs_hist2_peak_index = 0;
 	u32 dfs_hist1_pw = 0, dfs_hist2_pw = 0, g_pw[6] = {0};
-	u32 g_peakindex[16] = {0}, g_mask_32 = 0, false_peak_hist1 = 0;
-	u32 false_peak_hist2_above10 = 0, false_peak_hist2_above0 = 0;
+	u32 g_peakindex[16] = {0};
 	u32 dfs_hist1_pri = 0, dfs_hist2_pri = 0, g_pri[6] = {0};
 	u32 pw_sum_g0g5 = 0, pw_sum_g1g2g3g4 = 0;
 	u32 pri_sum_g0g5 = 0, pri_sum_g1g2g3g4 = 0;

--- a/hal/phydm/phydm_direct_bf.c
+++ b/hal/phydm/phydm_direct_bf.c
@@ -236,7 +236,6 @@ void phydm_set_direct_bfer(void *dm_void, u16 phs_idx, u8 su_idx)
 				  0x1df, 0x1e5, 0x1ea, 0x1ef, 0x1f5, 0x1fa,
 				  0x1c0}; //{Psi_4bit, Phi_6bit} of 0~360
 		u16 psiphiR;
-		u8 i;
 		u8 snr = 0x12; // for 1SS BF
 		u8 nc = 0x0; //bit 2-0
 		u8 nr = 0x1; //bit 5-3
@@ -342,8 +341,8 @@ void phydm_set_direct_bfer(void *dm_void, u16 phs_idx, u8 su_idx)
 /*only 1SS rate can improve performance*/
 void phydm_set_direct_bfer_txdesc_en(void *dm_void, u8 enable)
 {
-	struct dm_struct *dm = (struct dm_struct *)dm_void;
 #if (RTL8197G_SUPPORT)
+	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	if (dm->support_ic_type & ODM_RTL8197G) {
 		phydm_iq_gen_en(dm);
 

--- a/hal/phydm/phydm_math_lib.c
+++ b/hal/phydm/phydm_math_lib.c
@@ -86,7 +86,6 @@ s32 odm_sign_conversion(s32 value, u32 total_bit)
 /*threshold must form low to high*/
 u16 phydm_find_intrvl(void *dm_void, u16 val, u16 *threshold, u16 th_len)
 {
-	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u16 i = 0;
 	u16 ret_val = 0;
 	u16 max_th = threshold[th_len - 1];

--- a/hal/phydm/phydm_pathdiv.c
+++ b/hal/phydm/phydm_pathdiv.c
@@ -1089,7 +1089,9 @@ void phydm_c2h_dtp_handler(void *dm_void, u8 *cmd_buf, u8 cmd_len)
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct _ODM_PATH_DIVERSITY_ *p_div = &dm->dm_path_div;
 
+#ifdef CONFIG_RTW_DEBUG
 	u8 target = cmd_buf[1];
+#endif
 	u8 nsc_1 = cmd_buf[2];
 	u8 nsc_2 = cmd_buf[3];
 	u8 nsc_3 = cmd_buf[4];

--- a/hal/phydm/phydm_pathdiv.c
+++ b/hal/phydm/phydm_pathdiv.c
@@ -1089,7 +1089,6 @@ void phydm_c2h_dtp_handler(void *dm_void, u8 *cmd_buf, u8 cmd_len)
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct _ODM_PATH_DIVERSITY_ *p_div = &dm->dm_path_div;
 
-	u8 macid = cmd_buf[0];
 	u8 target = cmd_buf[1];
 	u8 nsc_1 = cmd_buf[2];
 	u8 nsc_2 = cmd_buf[3];

--- a/hal/phydm/phydm_phystatus.c
+++ b/hal/phydm/phydm_phystatus.c
@@ -1356,7 +1356,6 @@ void phydm_process_rssi_for_dm(struct dm_struct *dm,
 	s32 rssi_ave = 0; /*@average among all paths*/
 	s8 rssi_all = 0; /*@average value of CCK & OFDM*/
 	s8 rssi_cck_tmp = 0, rssi_ofdm_tmp = 0;
-	u8 i = 0;
 	u8 rssi_max = 0, rssi_min = 0;
 	u32 w1 = 0, w2 = 0; /*weighting*/
 	u8 send_rssi_2_fw = 0;

--- a/hal/phydm/phydm_rainfo.c
+++ b/hal/phydm/phydm_rainfo.c
@@ -818,7 +818,6 @@ void phydm_show_sta_info(void *dm_void, char input[][16], u32 *_used,
 
 u8 phydm_get_rx_stream_num(void *dm_void, enum rf_type type)
 {
-	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u8 rx_num = 1;
 
 	if (type == RF_1T1R)

--- a/hal/phydm/phydm_rainfo.c
+++ b/hal/phydm/phydm_rainfo.c
@@ -373,11 +373,13 @@ void phydm_ra_dynamic_retry_count(void *dm_void)
 void phydm_print_rate(void *dm_void, u8 rate, u32 dbg_component)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
+#ifdef CONFIG_RTW_DEBUG
 	u8 rate_idx = rate & 0x7f; /*remove bit7 SGI*/
 	boolean vht_en = phydm_is_vht_rate(dm, rate_idx);
 	u8 b_sgi = (rate & 0x80) >> 7;
 	u8 rate_ss = phydm_rate_to_num_ss(dm, rate_idx);
 	u8 rate_digit = phydm_rate_2_rate_digit(dm, rate_idx);
+#endif
 
 	PHYDM_DBG_F(dm, dbg_component, "( %s%s%s%s%s%d%s%s)\n",
 		    (vht_en && (rate_ss == 1)) ? "VHT 1ss " : "",

--- a/hal/phydm/phydm_rssi_monitor.c
+++ b/hal/phydm/phydm_rssi_monitor.c
@@ -159,7 +159,6 @@ void phydm_rssi_monitor_check(void *dm_void)
 void phydm_rssi_monitor_init(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct ra_table *ra_tab = &dm->dm_ra_table;
 
 	dm->pre_rssi_min = 0;
 	dm->rssi_max = 0;

--- a/hal/phydm/phydm_soml.c
+++ b/hal/phydm/phydm_soml.c
@@ -139,7 +139,6 @@ void phydm_adaptive_soml_workitem_callback(void *context)
 void phydm_adaptive_soml_callback(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	void *padapter = dm->adapter;
 
 	if (*dm->is_net_closed == true)
 		return;
@@ -509,7 +508,6 @@ void phydm_soml_stats_vht_off(void *dm_void)
 void phydm_soml_statistics(void *dm_void, u8 on_off_state)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
-	struct adaptive_soml *soml_tab = &dm->dm_soml_table;
 
 	if (on_off_state == SOML_ON) {
 		if (*dm->channel <= 14)
@@ -576,7 +574,7 @@ void phydm_adsl_odd_state(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct adaptive_soml *soml_tab = &dm->dm_soml_table;
-	u16 ht_reset[HT_RATE_IDX] = {0}, vht_reset[VHT_RATE_IDX] = {0};
+	u16 ht_reset[HT_RATE_IDX] = {0};
 	u8 size = sizeof(ht_reset[0]);
 
 	soml_tab->get_stats = true;

--- a/hal/phydm/rtl8822b/halhwimg8822b_bb.c
+++ b/hal/phydm/rtl8822b/halhwimg8822b_bb.c
@@ -36,8 +36,11 @@ check_positive(struct dm_struct *dm,
 	       const u32	condition4
 )
 {
-	u32	cond1 = condition1, cond2 = condition2,
-		cond3 = condition3, cond4 = condition4;
+	u32	cond1 = condition1;
+#ifdef CONFIG_RTW_DEBUG
+	u32	cond2 = condition2, cond3 = condition3,
+		cond4 = condition4;
+#endif
 
 	u8	cut_version_for_para =
 		(dm->cut_version ==  ODM_CUT_A) ? 15 : dm->cut_version;
@@ -52,6 +55,7 @@ check_positive(struct dm_struct *dm,
 			(dm->support_interface & 0x0F) << 8  |
 			dm->rfe_type;
 
+#ifdef CONFIG_RTW_DEBUG
 	u32	driver2 = (dm->type_glna & 0xFF) <<  0 |
 			(dm->type_gpa & 0xFF)  <<  8 |
 			(dm->type_alna & 0xFF) << 16 |
@@ -63,6 +67,7 @@ check_positive(struct dm_struct *dm,
 			(dm->type_gpa & 0xFF00) |
 			(dm->type_alna & 0xFF00) << 8 |
 			(dm->type_apa & 0xFF00)  << 16;
+#endif
 
 	PHYDM_DBG(dm, ODM_COMP_INIT,
 		  "===> %s (cond1, cond2, cond3, cond4) = (0x%X 0x%X 0x%X 0x%X)\n",

--- a/hal/phydm/rtl8822b/halhwimg8822b_mac.c
+++ b/hal/phydm/rtl8822b/halhwimg8822b_mac.c
@@ -36,8 +36,11 @@ check_positive(struct dm_struct *dm,
 	       const u32	condition4
 )
 {
-	u32	cond1 = condition1, cond2 = condition2,
-		cond3 = condition3, cond4 = condition4;
+	u32	cond1 = condition1;
+#ifdef CONFIG_RTW_DEBUG
+	u32	cond2 = condition2, cond3 = condition3,
+		cond4 = condition4;
+#endif
 
 	u8	cut_version_for_para =
 		(dm->cut_version ==  ODM_CUT_A) ? 15 : dm->cut_version;
@@ -52,6 +55,7 @@ check_positive(struct dm_struct *dm,
 			(dm->support_interface & 0x0F) << 8  |
 			dm->rfe_type;
 
+#ifdef CONFIG_RTW_DEBUG
 	u32	driver2 = (dm->type_glna & 0xFF) <<  0 |
 			(dm->type_gpa & 0xFF)  <<  8 |
 			(dm->type_alna & 0xFF) << 16 |
@@ -63,6 +67,7 @@ check_positive(struct dm_struct *dm,
 			(dm->type_gpa & 0xFF00) |
 			(dm->type_alna & 0xFF00) << 8 |
 			(dm->type_apa & 0xFF00)  << 16;
+#endif
 
 	PHYDM_DBG(dm, ODM_COMP_INIT,
 		  "===> %s (cond1, cond2, cond3, cond4) = (0x%X 0x%X 0x%X 0x%X)\n",

--- a/hal/phydm/txbf/phydm_hal_txbf_api.c
+++ b/hal/phydm/txbf/phydm_hal_txbf_api.c
@@ -674,7 +674,6 @@ void phydm_bf_debug(void *dm_void, char input[][16], u32 *_used, char *output,
 		#endif
 	} else if (var1[0] == 1) {
 		#ifdef PHYDM_IC_JGR3_SERIES_SUPPORT
-		struct dm_struct *dm = (struct dm_struct *)dm_void;
 		struct phydm_bf_rate_info_jgr3 *bfinfo = &dm->bf_rate_info_jgr3;
 
 		bfinfo->enable = (u8)var1[1];

--- a/hal/rtl8822b/rtl8822b_cmd.c
+++ b/hal/rtl8822b/rtl8822b_cmd.c
@@ -100,7 +100,6 @@ void rtl8822b_req_txrpt_cmd(PADAPTER adapter, u8 macid)
 
 void rtl8822b_set_FwPwrMode_cmd(PADAPTER adapter, u8 psmode)
 {
-	int i;
 	u8 smart_ps = 0, mode = 0;
 	struct pwrctrl_priv *pwrpriv = adapter_to_pwrctl(adapter);
 #ifdef CONFIG_BCN_RECV_TIME
@@ -372,10 +371,9 @@ C2HTxRPTHandler_8822b(
 		u8			CmdLen
 )
 {
-	_irqL	 irqL;
 	u8 macid = 0, IniRate = 0;
 	u16 TxOK = 0, TxFail = 0;
-	struct sta_priv	*pstapriv = &(GET_PRIMARY_ADAPTER(Adapter))->stapriv, *pstapriv_original = NULL;
+	struct sta_priv	*pstapriv = &(GET_PRIMARY_ADAPTER(Adapter))->stapriv;
 	u8 TxOK0 = 0, TxOK1 = 0;
 	u8 TxFail0 = 0, TxFail1 = 0;
 	struct sta_info *psta = NULL;
@@ -419,12 +417,8 @@ C2HSPC_STAT_8822b(
 		u8			CmdLen
 )
 {
-	_irqL	 irqL;
 	struct sta_priv *pstapriv = &(GET_PRIMARY_ADAPTER(Adapter))->stapriv;
 	struct sta_info *psta = NULL;
-	struct sta_info *pbcmc_stainfo = rtw_get_bcmc_stainfo(Adapter);
-	_list	*plist, *phead;
-	u8 idx = C2H_SPECIAL_STATISTICS_GET_STATISTICS_IDX(CmdBuf);
 	PADAPTER	adapter_ognl = NULL;
 
 	if(!pstapriv->gotc2h) {

--- a/hal/rtl8822b/rtl8822b_halinit.c
+++ b/hal/rtl8822b/rtl8822b_halinit.c
@@ -75,7 +75,6 @@ void rtl8822b_init_hal_spec(PADAPTER adapter)
 u32 rtl8822b_power_on(PADAPTER adapter)
 {
 	struct dvobj_priv *d;
-	PHAL_DATA_TYPE hal;
 	u8 bMacPwrCtrlOn;
 	int err = 0;
 	u8 ret = _SUCCESS;
@@ -203,7 +202,6 @@ u8 rtl8822b_mac_verify(PADAPTER adapter)
 void rtl8822b_init_misc(PADAPTER adapter)
 {
 	PHAL_DATA_TYPE hal;
-	u8 v8 = 0;
 	u32 v32 = 0;
 #ifdef RTW_AMPDU_AGG_RETRY_AND_NEW
 	u32 ctrl;
@@ -343,7 +341,6 @@ u32 rtl8822b_deinit(PADAPTER adapter)
 void rtl8822b_init_default_value(PADAPTER adapter)
 {
 	PHAL_DATA_TYPE hal;
-	u8 i;
 
 
 	hal = GET_HAL_DATA(adapter);

--- a/hal/rtl8822b/rtl8822b_mac.c
+++ b/hal/rtl8822b/rtl8822b_mac.c
@@ -107,7 +107,6 @@ s32 rtl8822b_fw_dl(PADAPTER adapter, u8 wowlan)
 {
 	struct dvobj_priv *d = adapter_to_dvobj(adapter);
 	HAL_DATA_TYPE *hal = GET_HAL_DATA(adapter);
-	struct pwrctrl_priv *pwrpriv = adapter_to_pwrctl(adapter);
 	int err;
 	u8 fw_bin = _TRUE;
 

--- a/hal/rtl8822b/rtl8822b_ops.c
+++ b/hal/rtl8822b/rtl8822b_ops.c
@@ -276,7 +276,6 @@ static void Hal_EfuseParseBTCoexistInfo(PADAPTER adapter, u8 *map, u8 mapvalid)
 {
 	PHAL_DATA_TYPE hal = GET_HAL_DATA(adapter);
 	u8 setting;
-	u32 tmpu4;
 
 	if ((_TRUE == mapvalid) && (map[EEPROM_RF_BOARD_OPTION_8822B] != 0xFF)) {
 		/* 0xc1[7:5] = 0x01 */
@@ -782,11 +781,9 @@ static void beacon_function_enable(PADAPTER adapter, u8 Enable, u8 Linked)
 static void set_beacon_related_registers(PADAPTER adapter)
 {
 	u8 val8;
-	u32 value32;
-	PHAL_DATA_TYPE hal = GET_HAL_DATA(adapter);
 	struct mlme_ext_priv *pmlmeext = &adapter->mlmeextpriv;
 	struct mlme_ext_info *pmlmeinfo = &pmlmeext->mlmext_info;
-	u32 bcn_ctrl_reg, bcn_interval_reg;
+	u32 bcn_ctrl_reg;
 
 
 	/* reset TSF, enable update TSF, correcting TSF On Beacon */
@@ -931,7 +928,6 @@ static void linked_status_check(PADAPTER p)
 {
 	PHAL_DATA_TYPE hal = GET_HAL_DATA(p);
 	struct sreset_priv *psrtpriv = &hal->srestpriv;
-	struct	pwrctrl_priv *pwrpriv = adapter_to_pwrctl(p);
 	u32 rx_dma_status = 0;
 
 	rx_dma_status = rtw_read32(p, REG_RXDMA_STATUS_8822B);
@@ -967,7 +963,6 @@ static void set_opmode_monitor(PADAPTER adapter)
 {
 	u32 rcr_bits;
 	u16 value_rxfltmap2;
-	struct mlme_priv *pmlmepriv = &adapter->mlmepriv;
 
 
 	/* Receive all type */
@@ -993,7 +988,6 @@ static void set_opmode_port0(PADAPTER adapter, u8 mode)
 	u8 is_tx_bcn;
 	u8 val8;
 	u16 val16;
-	u32 val32;
 
 
 #ifdef CONFIG_CONCURRENT_MODE
@@ -1252,7 +1246,6 @@ void rtw_hw_client_port_clr(_adapter *adapter)
 
 static void hw_var_set_opmode(PADAPTER adapter, u8 mode)
 {
-	u8 val8;
 	static u8 isMonitor = _FALSE;
 
 
@@ -1436,10 +1429,7 @@ static void hw_var_set_mlme_sitesurvey(PADAPTER adapter, u8 enable)
 	struct dvobj_priv *dvobj;
 	PHAL_DATA_TYPE hal;
 	struct mlme_priv *pmlmepriv;
-	PADAPTER iface;
-	u32 reg_bcn_ctl;
 	u16 value_rxfltmap2;
-	u8 val8, i;
 
 
 	dvobj = adapter_to_dvobj(adapter);
@@ -1489,7 +1479,6 @@ static void hw_var_set_mlme_join(PADAPTER adapter, u8 type)
 {
 	u8 val8;
 	u16 val16;
-	u32 val32;
 	u8 RetryLimit;
 	PHAL_DATA_TYPE hal;
 	struct mlme_priv *pmlmepriv;
@@ -1677,10 +1666,8 @@ static void hw_var_set_ack_preamble(PADAPTER adapter, u8 bShortPreamble)
 
 void hw_var_set_dl_rsvd_page(PADAPTER adapter, u8 mstatus)
 {
-	PHAL_DATA_TYPE hal = GET_HAL_DATA(adapter);
 	struct mlme_ext_priv *pmlmeext = &adapter->mlmeextpriv;
 	struct mlme_ext_info *pmlmeinfo = &pmlmeext->mlmext_info;
-	struct pwrctrl_priv *pwrpriv = adapter_to_pwrctl(adapter);
 	u8 bcn_valid = _FALSE;
 	u8 DLBcnCount = 0;
 	u32 poll = 0;
@@ -2536,10 +2523,8 @@ void rtl8822b_read_wmmedca_reg(PADAPTER adapter, u16 *vo_params, u16 *vi_params,
 void rtl8822b_gethwreg(PADAPTER adapter, u8 variable, u8 *val)
 {
 	PHAL_DATA_TYPE hal;
-	u8 val8;
 	u16 val16;
 	u32 val32;
-	u64 val64;
 
 
 	hal = GET_HAL_DATA(adapter);
@@ -3265,7 +3250,7 @@ void rtl8822b_prepare_mp_txdesc(PADAPTER adapter, struct mp_priv *pmp_priv)
 	u32 pkt_size;
 	s32 bmcast;
 	u32 desc_size;
-	u8 data_rate, pwr_status, offset;
+	u8 offset;
 
 
 	desc = pmp_priv->tx.desc;

--- a/hal/rtl8822b/rtl8822b_phy.c
+++ b/hal/rtl8822b/rtl8822b_phy.c
@@ -425,7 +425,6 @@ static void init_phydm_cominfo(PADAPTER adapter)
 {
 	PHAL_DATA_TYPE hal;
 	struct dm_struct *p_dm_odm;
-	u32 support_ability = 0;
 	u8 cut_ver = ODM_CUT_A, fab_ver = ODM_TSMC;
 
 
@@ -500,7 +499,6 @@ static void check_rxfifo_full(PADAPTER adapter)
 	struct dvobj_priv *psdpriv = adapter->dvobj;
 	struct debug_priv *pdbgpriv = &psdpriv->drv_dbg;
 	struct registry_priv *regsty = &adapter->registrypriv;
-	u8 val8 = 0;
 
 	if (regsty->check_hw_status == 1) {
 		pdbgpriv->dbg_rx_fifo_last_overflow = pdbgpriv->dbg_rx_fifo_curr_overflow;
@@ -793,7 +791,6 @@ exit:
  */
 static u8 need_switch_band(PADAPTER adapter, u8 channelToSW)
 {
-	u8 u1tmp = 0;
 	u8 ret_value = _TRUE;
 	u8 Band = BAND_ON_5G, BandToSW = BAND_ON_5G;
 	PHAL_DATA_TYPE hal = GET_HAL_DATA(adapter);
@@ -875,7 +872,7 @@ static void switch_chnl_and_set_bw_by_drv(PADAPTER adapter, u8 switch_band)
 {
 	PHAL_DATA_TYPE hal = GET_HAL_DATA(adapter);
 	struct dm_struct *p_dm_odm = &hal->odmpriv;
-	u8 center_ch = 0, ret = 0;
+	u8 ret = 0;
 
 	/* set channel & Bandwidth register */
 	/* 1. set switch band register if need to switch band */
@@ -945,7 +942,7 @@ void rtl8822b_switch_chnl_and_set_bw(PADAPTER adapter)
 {
 	PHAL_DATA_TYPE hal = GET_HAL_DATA(adapter);
 	struct dm_struct *p_dm_odm = &hal->odmpriv;
-	u8 center_ch = 0, ret = 0, switch_band = _FALSE;
+	u8 switch_band = _FALSE;
 
 	if (adapter->bNotifyChannelChange) {
 		RTW_INFO("[%s] bSwChnl=%d, ch=%d, bSetChnlBW=%d, bw=%d\n",
@@ -1072,7 +1069,6 @@ void rtl8822b_handle_sw_chnl_and_set_bw(
 	u8 tmpnCur40MhzPrimeSC = hal->nCur40MhzPrimeSC;
 	u8 tmpnCur80MhzPrimeSC = hal->nCur80MhzPrimeSC;
 	u8 tmpCenterFrequencyIndex1 = hal->CurrentCenterFrequencyIndex1;
-	struct mlme_ext_priv *pmlmeext = &Adapter->mlmeextpriv;
 
 
 	/* check swchnl or setbw */
@@ -1591,7 +1587,6 @@ static void _config_beamformer_mu(PADAPTER adapter, struct beamformer_entry *bfe
 	u32 csi_param;
 	/* Misc */
 	u8 i, val8;
-	u16 val16;
 
 	RTW_INFO("%s: Config MU BFer entry HW setting\n", __FUNCTION__);
 
@@ -1652,8 +1647,6 @@ static void _config_beamformee_su(PADAPTER adapter, struct beamformee_entry *bfe
 	u8 idx;
 	u16 p_aid = 0;
 	/* Misc */
-	u8 val8;
-	u16 val16;
 	u32 val32;
 
 
@@ -1969,7 +1962,7 @@ static void _reset_beamformee_mu(PADAPTER adapter, struct beamformee_entry *bfee
 void rtl8822b_phy_bf_reset_all(PADAPTER adapter)
 {
 	struct beamforming_info *info;
-	u8 i, val8;
+	u8 i;
 	u32 val32;
 
 

--- a/hal/rtl8822b/usb/rtl8822bu_halinit.c
+++ b/hal/rtl8822b/usb/rtl8822bu_halinit.c
@@ -193,7 +193,9 @@ static void hal_init_misc(PADAPTER adapter)
 u32 rtl8822bu_init(PADAPTER padapter)
 {
 	u8 status = _SUCCESS;
+#ifdef CONFIG_RTW_DEBUG
 	systime init_start_time = rtw_get_current_time();
+#endif
 
 #ifdef CONFIG_FWLPS_IN_IPS
 	if (_SUCCESS == rtl8822bu_fw_ips_init(padapter))

--- a/hal/rtl8822b/usb/rtl8822bu_halinit.c
+++ b/hal/rtl8822b/usb/rtl8822bu_halinit.c
@@ -226,9 +226,6 @@ static void hal_deinit_misc(PADAPTER adapter)
 
 u32 rtl8822bu_deinit(PADAPTER padapter)
 {
-	struct pwrctrl_priv *pwrctl = adapter_to_pwrctl(padapter);
-	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(padapter);
-	struct dvobj_priv *pobj_priv = adapter_to_dvobj(padapter);
 	u8 status = _TRUE;
 
 	RTW_INFO("==> %s\n", __func__);

--- a/hal/rtl8822b/usb/rtl8822bu_ops.c
+++ b/hal/rtl8822b/usb/rtl8822bu_ops.c
@@ -37,7 +37,6 @@ static u8 sethwreg(PADAPTER padapter, u8 variable, u8 *val)
 {
 	HAL_DATA_TYPE *pHalData = GET_HAL_DATA(padapter);
 	struct dvobj_priv	*pdvobjpriv = adapter_to_dvobj(padapter);
-	struct pwrctrl_priv *pwrctl = adapter_to_pwrctl(padapter);
 	struct registry_priv *registry_par = &padapter->registrypriv;
 	int status = 0;
 	u8 ret = _SUCCESS;
@@ -125,8 +124,6 @@ static u8 sethwreg(PADAPTER padapter, u8 variable, u8 *val)
 
 static void gethwreg(PADAPTER padapter, u8 variable, u8 *val)
 {
-	HAL_DATA_TYPE *pHalData = GET_HAL_DATA(padapter);
-
 	switch (variable) {
 	case HW_VAR_CPWM:
 #ifdef CONFIG_LPS_LCLK
@@ -154,7 +151,6 @@ static void gethwreg(PADAPTER padapter, u8 variable, u8 *val)
 */
 static u8 sethaldefvar(PADAPTER padapter, HAL_DEF_VARIABLE eVariable, void *pValue)
 {
-	HAL_DATA_TYPE *pHalData = GET_HAL_DATA(padapter);
 	u8 bResult = _SUCCESS;
 
 	switch (eVariable) {
@@ -172,7 +168,6 @@ static u8 sethaldefvar(PADAPTER padapter, HAL_DEF_VARIABLE eVariable, void *pVal
 */
 static u8 gethaldefvar(PADAPTER	padapter, HAL_DEF_VARIABLE eVariable, void *pValue)
 {
-	HAL_DATA_TYPE *pHalData = GET_HAL_DATA(padapter);
 	u8 bResult = _SUCCESS;
 
 	switch (eVariable) {

--- a/hal/rtl8822b/usb/rtl8822bu_recv.c
+++ b/hal/rtl8822b/usb/rtl8822bu_recv.c
@@ -75,10 +75,8 @@ int recvbuf2recvframe(PADAPTER padapter, void *ptr)
 	u8 pkt_cnt = 0;
 	u32 pkt_offset;
 	s32 transfer_len;
-	u8 *pphy_status = NULL;
 	union recv_frame *precvframe = NULL;
 	struct rx_pkt_attrib *pattrib = NULL;
-	HAL_DATA_TYPE *pHalData = GET_HAL_DATA(padapter);
 	struct recv_priv *precvpriv = &padapter->recvpriv;
 	_queue *pfree_recv_queue = &precvpriv->free_recv_queue;
 	_pkt *pskb;

--- a/hal/rtl8822b/usb/rtl8822bu_xmit.c
+++ b/hal/rtl8822b/usb/rtl8822bu_xmit.c
@@ -35,10 +35,8 @@ static void update_txdesc_h2c_pkt(struct xmit_frame *pxmitframe, u8 *pmem, s32 s
 static s32 update_txdesc(struct xmit_frame *pxmitframe, u8 *pmem, s32 sz, u8 bagg_pkt)
 {
 	int pull = 0;
-	uint qsel;
-	u8 data_rate, pwr_status, offset;
+	u8 offset;
 	_adapter *padapter = pxmitframe->padapter;
-	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
 	struct pkt_attrib *pattrib = &pxmitframe->attrib;
 	HAL_DATA_TYPE *pHalData = GET_HAL_DATA(padapter);
 	u8 *ptxdesc =  pmem;
@@ -904,7 +902,6 @@ static s32 pre_xmitframe(PADAPTER padapter, struct xmit_frame *pxmitframe)
 	struct xmit_buf *pxmitbuf = NULL;
 	struct xmit_priv *pxmitpriv = &padapter->xmitpriv;
 	struct pkt_attrib *pattrib = &pxmitframe->attrib;
-	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
 
 	_enter_critical_bh(&pxmitpriv->lock, &irqL);
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1756,7 +1756,9 @@ static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct net_device *ndev
 	struct ieee_param *param = NULL;
 	int ret = 0;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
+#ifdef CONFIG_RTW_DEBUG
 	struct wireless_dev *rtw_wdev = padapter->rtw_wdev;
+#endif
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
 #ifdef CONFIG_TDLS
 	struct sta_info *ptdls_sta;
@@ -4308,7 +4310,11 @@ exit:
 static int cfg80211_rtw_disconnect(struct wiphy *wiphy, struct net_device *ndev,
 				   u16 reason_code)
 {
+#ifdef CONFIG_RTW_DEBUG
+#if (RTW_CFG80211_BLOCK_STA_DISCON_EVENT & RTW_CFG80211_BLOCK_DISCON_WHEN_DISCONNECT)
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
+#endif
+#endif
 
 	RTW_INFO(FUNC_NDEV_FMT" - Start to Disconnect\n", FUNC_NDEV_ARG(ndev));
 
@@ -4330,6 +4336,7 @@ static int cfg80211_rtw_disconnect(struct wiphy *wiphy, struct net_device *ndev,
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 31))
+#ifdef CONFIG_RTW_DEBUG
 static const char *nl80211_tx_power_setting_str(int type)
 {
 	switch (type) {
@@ -4343,6 +4350,7 @@ static const char *nl80211_tx_power_setting_str(int type)
 		return "UNKNOWN";
 	};
 }
+#endif
 
 static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4499,7 +4499,6 @@ static int cfg80211_rtw_set_pmksa(struct wiphy *wiphy,
 				  struct net_device *ndev,
 				  struct cfg80211_pmksa *pmksa)
 {
-	u8	index, blInserted = _FALSE;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 	struct mlme_priv *mlme = &padapter->mlmepriv;
 	struct security_priv	*psecuritypriv = &padapter->securitypriv;
@@ -7809,10 +7808,6 @@ static void cfg80211_rtw_update_mgmt_frame_register(struct wiphy *wiphy,
 						    struct mgmt_frame_regs *upd)
 #endif
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0))
-	u32 rtw_mask = BIT(IEEE80211_STYPE_PROBE_REQ >> 4);
-#endif
-
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0))
 	struct net_device *ndev = wdev_to_ndev(wdev);
 #endif
@@ -10069,8 +10064,6 @@ int rtw_hostapd_acs_dump_survey(struct wiphy *wiphy, struct net_device *netdev, 
 int cfg80211_rtw_external_auth(struct wiphy *wiphy, struct net_device *dev,
 	struct cfg80211_external_auth_params *params)
 {
-	PADAPTER padapter = (_adapter *)rtw_netdev_priv(dev);
-
 	RTW_INFO(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(dev));
 
 	rtw_cfg80211_external_auth_status(wiphy, dev,

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -5244,7 +5244,9 @@ static int rtw_p2p_set_wfd_enable(struct net_device *dev,
 
 	int ret = 0;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
+#ifdef CONFIG_RTW_DEBUG
 	struct wifidirect_info *pwdinfo = &(padapter->wdinfo);
+#endif
 
 	if (*extra == '0')
 		rtw_wfd_enable(padapter, 0);
@@ -5836,7 +5838,9 @@ static int rtw_dbg_port(struct net_device *dev,
 	struct mlme_priv *pmlmepriv = &(padapter->mlmepriv);
 	struct mlme_ext_priv	*pmlmeext = &padapter->mlmeextpriv;
 	struct mlme_ext_info	*pmlmeinfo = &(pmlmeext->mlmext_info);
+#ifdef CONFIG_RTW_DEBUG
 	struct security_priv *psecuritypriv = &padapter->securitypriv;
+#endif
 	struct wlan_network *cur_network = &(pmlmepriv->cur_network);
 	struct sta_priv *pstapriv = &padapter->stapriv;
 
@@ -6155,8 +6159,10 @@ static int rtw_dbg_port(struct net_device *dev,
 				, rtw_is_drv_stopped(padapter) ? "True" : "False");
 			break;
 		case 0x08: {
+#ifdef CONFIG_RTW_DEBUG
 			struct xmit_priv *pxmitpriv = &padapter->xmitpriv;
 			struct recv_priv  *precvpriv = &padapter->recvpriv;
+#endif
 
 			RTW_INFO("free_xmitbuf_cnt=%d, free_xmitframe_cnt=%d"
 				", free_xmit_extbuf_cnt=%d, free_xframe_ext_cnt=%d"
@@ -6281,7 +6287,9 @@ static int rtw_dbg_port(struct net_device *dev,
 		}
 			break;
 		case 0x15: {
+#ifdef CONFIG_RTW_DEBUG
 			struct pwrctrl_priv *pwrpriv = adapter_to_pwrctl(padapter);
+#endif
 			RTW_INFO("==>silent resete cnts:%d\n", pwrpriv->ips_enter_cnts);
 		}
 			break;
@@ -6333,7 +6341,9 @@ static int rtw_dbg_port(struct net_device *dev,
 			break;
 #endif
 		case 0x14: { /* get wifi_spec */
+#ifdef CONFIG_RTW_DEBUG
 			struct registry_priv	*pregpriv = &padapter->registrypriv;
+#endif
 			RTW_INFO("get wifi_spec=%d\n", pregpriv->wifi_spec);
 
 		}

--- a/os_dep/linux/ioctl_mp.c
+++ b/os_dep/linux/ioctl_mp.c
@@ -1013,8 +1013,6 @@ int rtw_mp_ctx(struct net_device *dev,
 
 	} else if (stop == 0) {
 		struct xmit_priv	*pxmitpriv = &(padapter->xmitpriv);
-		_queue *pfree_xmitbuf_queue = &pxmitpriv->free_xmitbuf_queue;
-		_queue *pfree_xmit_queue = &pxmitpriv->free_xmit_queue;
 
 		u32 i = 0;
 		bStartTest = 0; /* To set Stop*/

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1701,7 +1701,9 @@ int rtw_ndev_init(struct net_device *dev)
 
 void rtw_ndev_uninit(struct net_device *dev)
 {
+#ifdef CONFIG_RTW_DEBUG
 	_adapter *adapter = rtw_netdev_priv(dev);
+#endif
 
 	RTW_PRINT(FUNC_ADPT_FMT" if%d\n"
 		  , FUNC_ADPT_ARG(adapter), (adapter->iface_id + 1));
@@ -3909,7 +3911,9 @@ int rtw_ips_pwr_up(_adapter *padapter)
 	struct sreset_priv *psrtpriv = &pHalData->srestpriv;
 #endif/* #ifdef DBG_CONFIG_ERROR_DETECT */
 #endif /* defined(CONFIG_SWLPS_IN_IPS) || defined(CONFIG_FWLPS_IN_IPS) */
+#ifdef CONFIG_RTW_DEBUG
 	systime start_time = rtw_get_current_time();
+#endif
 	RTW_INFO("===>  rtw_ips_pwr_up..............\n");
 
 #if defined(CONFIG_SWLPS_IN_IPS) || defined(CONFIG_FWLPS_IN_IPS)
@@ -3930,7 +3934,9 @@ int rtw_ips_pwr_up(_adapter *padapter)
 
 void rtw_ips_pwr_down(_adapter *padapter)
 {
+#ifdef CONFIG_RTW_DEBUG
 	systime start_time = rtw_get_current_time();
+#endif
 	RTW_INFO("===> rtw_ips_pwr_down...................\n");
 
 	padapter->net_closed = _TRUE;
@@ -4931,7 +4937,9 @@ int rtw_suspend_common(_adapter *padapter)
 #endif
 
 	int ret = 0;
+#ifdef CONFIG_RTW_DEBUG
 	systime start_time = rtw_get_current_time();
+#endif
 
 	RTW_PRINT(" suspend start\n");
 	RTW_INFO("==> %s (%s:%d)\n", __FUNCTION__, current->comm, current->pid);
@@ -5399,7 +5407,9 @@ exit:
 int rtw_resume_common(_adapter *padapter)
 {
 	int ret = 0;
+#ifdef CONFIG_RTW_DEBUG
 	systime start_time = rtw_get_current_time();
+#endif
 	struct pwrctrl_priv *pwrpriv = adapter_to_pwrctl(padapter);
 
 	if (pwrpriv == NULL)

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -963,7 +963,7 @@ module_param(rtw_suspend_type, uint, 0644);
 #if CONFIG_TX_AC_LIFETIME
 static void rtw_regsty_load_tx_ac_lifetime(struct registry_priv *regsty)
 {
-	int i, j;
+	int i;
 	struct tx_aclt_conf_t *conf;
 	uint *parm;
 

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -244,7 +244,6 @@ static int rtw_cfgvendor_send_cmd_reply(struct wiphy *wiphy,
 int rtw_dev_get_feature_set(struct net_device *dev)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	HAL_DATA_TYPE *HalData = GET_HAL_DATA(adapter);
 	int feature_set = 0;
 
 	feature_set |= WIFI_FEATURE_INFRA;

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -133,7 +133,9 @@ static int proc_get_drv_cfg(struct seq_file *m, void *v)
 static ssize_t proc_set_log_level(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	char tmp[32];
+#ifdef CONFIG_RTW_DEBUG
 	int log_level;
+#endif
 
 	if (count < 1)
 		return -EINVAL;

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -2271,7 +2271,6 @@ static ssize_t proc_set_tx_aclt_force_val(struct file *file, const char __user *
 	}
 
 	if (buffer && !copy_from_user(tmp, buffer, count)) {
-		struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 		struct tx_aclt_conf_t input;
 		int num = sscanf(tmp, "%hhx %u %u", &input.en, &input.vo_vi, &input.be_bk);
 
@@ -2350,7 +2349,6 @@ static ssize_t proc_set_tx_aclt_confs(struct file *file, const char __user *buff
 	}
 
 	if (buffer && !copy_from_user(tmp, buffer, count)) {
-		struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 		u8 id;
 		struct tx_aclt_conf_t input;
 		int num = sscanf(tmp, "%hhu %hhx %u %u", &id, &input.en, &input.vo_vi, &input.be_bk);

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2210,7 +2210,6 @@ static int writeFile(struct file *fp, char *buf, int len)
 static int isDirReadable(const char *pathname, u32 *sz)
 {
 	struct path path;
-	int error = 0;
 
 	return kern_path(pathname, LOOKUP_FOLLOW, &path);
 }


### PR DESCRIPTION
Locally I have managed to reach building the driver without `-Wno-unused-variable` and just having `-Werror` turned on to catch all the unused variables which gcc flagged up.
There is a combination of stuff that's just not referenced and can be deleted, stuff that's reliant on `CONFIG_RTW_DEBUG` for macros to work which reference the variables, and things that need guarding off for specific configuration definition.
This pull request starts off covering these cases. locally there are changes that are bodges just to skip over things but as I said, I do have the driver building and working without `-Wno-unused-variable`and just having `-Werror`, the build is silent.