### PR TITLE
Fix for 6.1.0-15-amd64  error: implicit declaration of function ‘pran…

### DIFF
--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2702,7 +2702,7 @@ inline u32 rtw_random32(void)
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
 	return get_random_u32();
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
-	return prandom_u32();
+	return prandom_u32_max();
 #elif (LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 18))
 	u32 random_int;
 	get_random_bytes(&random_int , 4);


### PR DESCRIPTION
Hello! I used your driver as it works so good, very reliable. But upgrading system got error because of it.

```
apt upgrade
The following packages were automatically installed and are no longer required:
  linux-headers-6.1.0-12-amd64 linux-headers-6.1.0-12-common
  linux-image-6.1.0-12-amd64

Building module:
Cleaning build area...
'make' KVER=6.1.0-15-amd64...............(bad exit status: 2)
Error! Bad return status for module build on kernel: 6.1.0-15-amd64 (x86_64)
Consult /var/lib/dkms/rtl8821CU/5.4.1/build/make.log for more information.
Error! One or more modules failed to install during autoinstall.
Refer to previous errors for more information.
dkms: autoinstall for kernel: 6.1.0-15-amd64 failed!
run-parts: /etc/kernel/postinst.d/dkms exited with return code 11
dpkg: error processing package linux-image-6.1.0-15-amd64 (--configure):
 installed linux-image-6.1.0-15-amd64 package post-installation script subproces
s returned error exit status 1
dpkg: dependency problems prevent configuration of linux-headers-amd64:
 linux-headers-amd64 depends on linux-headers-6.1.0-15-amd64 (= 6.1.66-1); howev
er:
  Package linux-headers-6.1.0-15-amd64 is not configured yet.

  Package linux-headers-6.1.0-15-amd64 is not configured yet.

dpkg: error processing package linux-headers-amd64 (--configure):
 dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of linux-image-amd64:
 linux-image-amd64 depends on linux-image-6.1.0-15-amd64 (= 6.1.66-1); however:
  Package linux-image-6.1.0-15-amd64 is not configured yet.

dpkg: error processing package linux-image-amd64 (--configure):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 linux-headers-6.1.0-15-amd64
 linux-image-6.1.0-15-amd64
 linux-headers-amd64
 linux-image-amd64
E: Sub-process /usr/bin/dpkg returned an error code (1)


vim /var/lib/dkms/rtl8821CU/5.4.1/build/make.log
/var/lib/dkms/rtl8821CU/5.4.1/build/os_dep/osdep_service.c: In function ‘rtw_change_ifname’:
/var/lib/dkms/rtl8821CU/5.4.1/build/os_dep/osdep_service.c:2494:28: warning: passing argument 1 of ‘_rtw_memcpy’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 2494 |         _rtw_memcpy(pnetdev->dev_addr, adapter_mac_addr(padapter), ETH_ALEN);
      |                     ~~~~~~~^~~~~~~~~~
/var/lib/dkms/rtl8821CU/5.4.1/build/os_dep/osdep_service.c:925:24: note: expected ‘void *’ but argument is of type ‘const unsigned char *’
  925 | void _rtw_memcpy(void *dst, const void *src, u32 sz)
      |                  ~~~~~~^~~
/var/lib/dkms/rtl8821CU/5.4.1/build/os_dep/osdep_service.c: In function ‘rtw_random32’:
/var/lib/dkms/rtl8821CU/5.4.1/build/os_dep/osdep_service.c:2618:16: error: implicit declaration of function ‘prandom_u32’; did you mean ‘prandom_u32_max’? [-Werror=implicit-function-declaration]
 2618 |         return prandom_u32();
      |                ^~~~~~~~~~~
      |                prandom_u32_max
cc1: some warnings being treated as errors
```

So I just followed recommendation from error and now have no issue on my system.

```
lsb_release -a
No LSB modules are available.
Distributor ID:	Devuan
Description:	Devuan GNU/Linux 5 (daedalus)
Release:	5
Codename:	daedalus

uname -a
Linux devuan 6.1.0-15-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.66-1 (2023-12-09) x86_64 GNU/Linux

gcc --version
gcc (Debian 12.2.0-14) 12.2.0
```

With my fix have no issues while upgrading.